### PR TITLE
Add Cursor Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Tricordarr",
+  "install": "npm ci && if [ ! -d node_modules/expo-modules-core ]; then ln -sfn expo/node_modules/expo-modules-core node_modules/expo-modules-core; fi",
+  "terminals": [
+    {
+      "name": "metro",
+      "command": "npm start",
+      "description": "React Native Metro dev server (JS bundler) on http://localhost:8081. Reachable from an Android emulator via 10.0.2.2 and iOS via 127.0.0.1."
+    }
+  ],
+  "ports": [
+    {
+      "name": "metro",
+      "port": 8081
+    }
+  ]
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,11 +1,11 @@
 {
   "name": "Tricordarr",
-  "install": "npm ci && if [ ! -d node_modules/expo-modules-core ]; then ln -sfn expo/node_modules/expo-modules-core node_modules/expo-modules-core; fi",
+  "install": "npm ci",
   "terminals": [
     {
-      "name": "metro",
-      "command": "npm start",
-      "description": "React Native Metro dev server (JS bundler) on http://localhost:8081. Reachable from an Android emulator via 10.0.2.2 and iOS via 127.0.0.1."
+      "name": "expo",
+      "command": "npx expo start",
+      "description": "Expo dev server (Metro JS bundler) on http://localhost:8081. Pairs with `npx expo run:android` / `npx expo run:ios`. Reachable from an Android emulator via 10.0.2.2 and an iOS simulator via 127.0.0.1."
     }
   ],
   "ports": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `.cursor/environment.json` so this repository is fully usable in Cursor Cloud Agents. There was no effective environment before (greenfield/override).

The config uses Cursor's default base image (Node 22 satisfies `engines.node >= 22.11.0`) and:

- **`install`**: `npm ci` (matches CI `lint.yml` and the README's `npm clean-install`; `postinstall` runs `patch-package`).
- **`terminals`**: runs the Expo dev server (`npx expo start`) on port `8081`, with logs visible to the agent. This pairs with the README's `npx expo run:android` / `npx expo run:ios` workflow.
- **`ports`**: exposes `8081` (reachable from an Android emulator via `10.0.2.2`, iOS simulator via `127.0.0.1`).

Native Android/iOS builds are intentionally out of scope — they require an emulator/simulator, and `AGENTS.md` directs builds to be run in the developer's own terminal.

## Note on `expo start` vs `react-native start`

The default `npm start` (`react-native start`) fails to bundle because `npm ci` nests `expo-modules-core@57.0.6` under `node_modules/expo/node_modules/` (the repo pins `react-native-worklets ^0.11.0`, outside that package's older peer range), and the community CLI's Metro resolver can't find it from the hoisted `expo-font`. The Expo CLI's Metro resolver handles the nested package on its own, so `npx expo start` bundles cleanly with a plain `npm ci` — no symlink or lockfile changes needed. Using `npx expo start` also matches the project's current Expo-based run commands.

## Validation (on the setup VM and a fresh Cloud Agent booted from the tested build)

| Check | Result |
| --- | --- |
| `npm ci` | Succeeded; idempotent (run twice) |
| `npm run typecheck` | Passed (exit 0) |
| `eslint .` | Passed (0 errors; 3 pre-existing unused-var warnings) |
| Expo dev server (`npx expo start`) | `packager-status:running` on `:8081` |
| Full Android JS bundle | HTTP 200, ~20.7 MB, 3791 modules |
| Full iOS JS bundle | HTTP 200, ~20.6 MB, 3788 modules |

Requesting the full `index.bundle` compiles the entire app source through Metro/Babel, so a 200 with ~3790 modules is an end-to-end proof that the app bundles.

### Note: pre-existing issue (not caused by this change)

`jest`: 3 of 5 suites fail with a `transformIgnorePatterns` config issue (`react-native-fs` isn't transformed, reached transitively via `node-ical` in `Schedule.ts`). This reproduces independent of the environment and is a repo test-config matter.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b1154fe-2104-45af-bdd1-a57fc1a7be78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b1154fe-2104-45af-bdd1-a57fc1a7be78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

