### PR TITLE
Include added-to Seamail count in the bottom tab badge

### DIFF
--- a/__tests__/unit/TestUserNotificationData.ts
+++ b/__tests__/unit/TestUserNotificationData.ts
@@ -1,0 +1,52 @@
+jest.mock('#src/Libraries/Logger', () => ({
+  createLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import {getBadgeDisplayValue} from '#src/Libraries/StringUtils';
+import {UserNotificationData} from '#src/Structs/ControllerStructs';
+
+const notificationData = (overrides: Partial<UserNotificationData>): UserNotificationData =>
+  ({
+    addedToSeamailCount: 0,
+    addedToLFGCount: 0,
+    addedToPrivateEventCount: 0,
+    newFezMessageCount: 0,
+    newPrivateEventMessageCount: 0,
+    alertWords: [],
+    ...overrides,
+  }) as UserNotificationData;
+
+describe('UserNotificationData.totalNewSeamail', () => {
+  it('returns 0 when notification data is missing', () => {
+    expect(UserNotificationData.totalNewSeamail(undefined)).toBe(0);
+  });
+
+  it('includes addedToSeamailCount in the seamail total used by the tab badge', () => {
+    const data = notificationData({
+      newSeamailMessageCount: 2,
+      addedToSeamailCount: 3,
+    });
+    expect(UserNotificationData.totalNewSeamail(data)).toBe(5);
+  });
+
+  it('shows a badge when the user was only added to seamails', () => {
+    const data = notificationData({
+      newSeamailMessageCount: 0,
+      addedToSeamailCount: 1,
+    });
+    expect(getBadgeDisplayValue(UserNotificationData.totalNewSeamail(data))).toBe(1);
+  });
+
+  it('hides the badge when there are no new messages and no added-to seamails', () => {
+    const data = notificationData({
+      newSeamailMessageCount: 0,
+      addedToSeamailCount: 0,
+    });
+    expect(getBadgeDisplayValue(UserNotificationData.totalNewSeamail(data))).toBeUndefined();
+  });
+});

--- a/src/Libraries/StringUtils.ts
+++ b/src/Libraries/StringUtils.ts
@@ -41,9 +41,8 @@ export const formatRegCodeDisplay = (code: string): string => {
 };
 
 /**
- * This is a helper function to get the badge display value for a given input.
- * The intention is that the badges should only be shown for new message count,
- * not for added to or other such things like that.
+ * Hide a tab/list badge when the count is 0. React Navigation treats a defined
+ * `tabBarBadge` as visible, so a 0 would otherwise render as a badge.
  *
  * @param input The number to check. If undefined or 0, returns undefined.
  * @returns The input value if it's greater than 0, otherwise undefined.

--- a/src/Navigation/Tabs/Bottom/BottomTabNavigator.tsx
+++ b/src/Navigation/Tabs/Bottom/BottomTabNavigator.tsx
@@ -12,6 +12,7 @@ import {MainStackNavigator} from '#src/Navigation/Stacks/Main/MainStackNavigator
 import {ScheduleStackNavigator} from '#src/Navigation/Stacks/Schedule/ScheduleStackNavigator';
 import {BottomTabComponents, BottomTabParamList} from '#src/Navigation/Tabs/Bottom/BottomTabComponents';
 import {useUserNotificationDataQuery} from '#src/Queries/Alert/NotificationQueries';
+import {UserNotificationData} from '#src/Structs/ControllerStructs';
 
 export const BottomTabNavigator = () => {
   const {data: userNotificationData} = useUserNotificationDataQuery({enabled: false});
@@ -22,7 +23,7 @@ export const BottomTabNavigator = () => {
   }, []);
 
   const getChatBadgeCount = useCallback(() => {
-    let count = userNotificationData?.newSeamailMessageCount || 0;
+    let count = UserNotificationData.totalNewSeamail(userNotificationData);
     if (userNotificationData?.moderatorData?.newModeratorSeamailMessageCount) {
       count += userNotificationData.moderatorData.newModeratorSeamailMessageCount;
     }

--- a/src/Structs/ControllerStructs.tsx
+++ b/src/Structs/ControllerStructs.tsx
@@ -222,6 +222,10 @@ export namespace UserNotificationData {
     );
   };
 
+  /**
+   * Unread seamail threads plus chats the user was added to but has not yet viewed.
+   * Used by the Seamail bottom-tab badge (along with privileged-account counts).
+   */
   export const totalNewSeamail = (data?: UserNotificationData) => {
     if (!data) {
       return 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/jocosocial/tricordarr/issues/528

The notifications menu already treated `addedToSeamailCount` as a new notification (`UserNotificationData.totalNewCount` / `totalNewSeamail`). The Seamail bottom-tab badge only used `newSeamailMessageCount`, so being added to a chat showed in the bell menu but not on the tab.

## Changes

- Seamail tab badge now uses `UserNotificationData.totalNewSeamail()`, which is unread threads plus chats the user was added to but has not viewed. Privileged-account (`@moderator` / `@TwitarrTeam`) counts are still added on top.
- Unit tests cover added-to-only, combined, and empty cases.
- `getBadgeDisplayValue` comment no longer claims badges should ignore added-to counts.

LFG and Schedule tab badges still use only new-message counts (`newFezMessageCount` / `newPrivateEventMessageCount`). Those have matching `totalNewLFG` / `totalNewPrivateEvent` helpers if we want the same treatment later.

## Testing

- `npx jest __tests__/unit/TestUserNotificationData.ts` — 4 passing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6983971-9da2-4371-b6d3-e73f1d20bcd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6983971-9da2-4371-b6d3-e73f1d20bcd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

