### PR TITLE
Add share button to performer profiles

### DIFF
--- a/__tests__/unit/TestShareContentType.ts
+++ b/__tests__/unit/TestShareContentType.ts
@@ -1,0 +1,14 @@
+import {ShareContentType} from '#src/Enums/ShareContentType';
+
+describe('ShareContentType.performer', () => {
+  it('uses the singular performer profile path, not the list path', () => {
+    expect(ShareContentType.performer).toBe('performer');
+    expect(ShareContentType.performer).not.toBe('performers');
+  });
+
+  it('builds the same URL shape ShareMenuItem uses for other content', () => {
+    const serverUrl = 'https://twitarr.com';
+    const performerID = 'abc-123';
+    expect(`${serverUrl}/${ShareContentType.performer}/${performerID}`).toBe('https://twitarr.com/performer/abc-123');
+  });
+});

--- a/src/Components/Menus/Performer/PerformerActionsMenu.tsx
+++ b/src/Components/Menus/Performer/PerformerActionsMenu.tsx
@@ -3,30 +3,34 @@ import {Divider, Menu} from 'react-native-paper';
 import {Item} from 'react-navigation-header-buttons';
 
 import {AppMenu} from '#src/Components/Menus/AppMenu';
+import {ShareMenuItem} from '#src/Components/Menus/Items/ShareMenuItem';
 import {usePrivilege} from '#src/Context/Contexts/PrivilegeContext';
 import {AppIcons} from '#src/Enums/Icons';
+import {ShareContentType} from '#src/Enums/ShareContentType';
 import {useMenu} from '#src/Hooks/useMenu';
 import {CommonStackComponents, useCommonStack} from '#src/Navigation/Stacks/Common/CommonStackComponents';
 import {PerformerData} from '#src/Structs/ControllerStructs';
 
 interface PerformerActionsMenuProps {
   performerData?: PerformerData;
+  performerID: string;
 }
 
-export const PerformerActionsMenu = ({performerData}: PerformerActionsMenuProps) => {
+export const PerformerActionsMenu = ({performerData, performerID}: PerformerActionsMenuProps) => {
   const {visible, openMenu, closeMenu} = useMenu();
   const {hasTwitarrTeam, hasModerator} = usePrivilege();
   const navigation = useCommonStack();
 
   // TypeScript + JSX = silly
   const creatorID = performerData?.user?.userID;
-  const performerID = performerData?.header.id;
 
   return (
     <AppMenu
       visible={visible}
       onDismiss={closeMenu}
       anchor={<Item title={'Actions'} iconName={AppIcons.menu} onPress={openMenu} />}>
+      <ShareMenuItem contentType={ShareContentType.performer} contentID={performerID} closeMenu={closeMenu} />
+      {((hasModerator && creatorID) || hasTwitarrTeam) && <Divider bold={true} />}
       {hasModerator && creatorID && (
         <>
           <Menu.Item
@@ -42,7 +46,7 @@ export const PerformerActionsMenu = ({performerData}: PerformerActionsMenuProps)
           <Divider bold={true} />
         </>
       )}
-      {hasTwitarrTeam && performerID && (
+      {hasTwitarrTeam && (
         <>
           <Menu.Item
             title={'Edit Performer'}

--- a/src/Enums/ShareContentType.ts
+++ b/src/Enums/ShareContentType.ts
@@ -8,5 +8,6 @@ export enum ShareContentType {
   lfg = 'lfg',
   user = 'user',
   event = 'events',
+  performer = 'performer',
   siteUI = 'siteui',
 }

--- a/src/Screens/Performer/PerformerHelpScreen.tsx
+++ b/src/Screens/Performer/PerformerHelpScreen.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import {AppView} from '#src/Components/Views/AppView';
 import {ScrollingContentView} from '#src/Components/Views/Content/ScrollingContentView';
+import {HelpButtonHelpTopicView} from '#src/Components/Views/Help/Common/HelpButtonHelpTopicView';
 import {OfficialPerformersHelpTopicView} from '#src/Components/Views/Help/Common/OfficialPerformersHelpTopicView';
 import {ShadowPerformerProfilesHelpTopicView} from '#src/Components/Views/Help/Common/ShadowPerformerProfilesHelpTopicView';
+import {ShareButtonHelpTopicView} from '#src/Components/Views/Help/Common/ShareButtonHelpTopicView';
 import {HelpChapterTitleView} from '#src/Components/Views/Help/HelpChapterTitleView';
 import {HelpTopicView} from '#src/Components/Views/Help/HelpTopicView';
 import {AppIcons} from '#src/Enums/Icons';
@@ -20,7 +22,15 @@ export const PerformerHelpScreen = () => {
           </HelpTopicView>
         </HelpChapterTitleView>
         <ShadowPerformerProfilesHelpTopicView />
+        <HelpChapterTitleView title={'Actions'}>
+          <ShareButtonHelpTopicView />
+          <HelpButtonHelpTopicView />
+        </HelpChapterTitleView>
         <HelpChapterTitleView title={'Privileged Actions'}>
+          <HelpTopicView title={'View Creator Profile'} icon={AppIcons.moderator}>
+            Open the Twitarr user profile of the person who created this performer bio. This is only available for
+            Shadow performers and only to moderators.
+          </HelpTopicView>
           <HelpTopicView title={'Add Performer'} icon={AppIcons.twitarteam}>
             Add a new performer profile. This should only be used for official cruise guests.
           </HelpTopicView>

--- a/src/Screens/Performer/PerformerScreen.tsx
+++ b/src/Screens/Performer/PerformerScreen.tsx
@@ -46,7 +46,7 @@ const PerformerScreenInner = ({route, navigation}: Props) => {
               }
             />
           )}
-          <PerformerActionsMenu performerData={data} />
+          <PerformerActionsMenu performerData={data} performerID={route.params.id} />
         </MaterialHeaderButtons>
       </View>
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #529.

Official and shadow performer profiles now have the same Share action as events, users, forums, and LFGs. Tap copies `https://<server>/performer/<id>` to the clipboard; long-press opens that URL in the browser.

## Changes

- Add `ShareContentType.performer` (`performer`, matching the existing deep-link path)
- Add `ShareMenuItem` to the performer profile Actions menu
- Document Share (and Help) under Actions in performer help
- Document the existing moderator-only View Creator Profile action

## How to test

1. Open an official performer profile and a shadow performer profile.
2. Open the header Actions menu and tap Share. Confirm the clipboard URL is `/performer/<id>` (singular, not `/performers`).
3. Long-press Share and confirm the URL opens in the browser.
4. Open performer Help and confirm the Actions chapter includes Share.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc7756c0-808b-4f11-a50e-6a43d1c160ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc7756c0-808b-4f11-a50e-6a43d1c160ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

