### PR TITLE
Remove header edit button from user profiles

### DIFF
--- a/src/Screens/User/UserProfileScreenBase.tsx
+++ b/src/Screens/User/UserProfileScreenBase.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import {Text} from 'react-native-paper';
-import {Item} from 'react-navigation-header-buttons';
 
 import {BlockedOrMutedBanner} from '#src/Components/Banners/BlockedOrMutedBanner';
 import {UserProfileFABGroup} from '#src/Components/Buttons/FloatingActionButtons/UserProfileFABGroup';
@@ -26,7 +25,6 @@ import {useOobe} from '#src/Context/Contexts/OobeContext';
 import {usePreRegistration} from '#src/Context/Contexts/PreRegistrationContext';
 import {useSession} from '#src/Context/Contexts/SessionContext';
 import {useStyles} from '#src/Context/Contexts/StyleContext';
-import {AppIcons} from '#src/Enums/Icons';
 import {useClipboard} from '#src/Hooks/useClipboard';
 import {useRefresh} from '#src/Hooks/useRefresh';
 import {CommonStackComponents, useCommonStack} from '#src/Navigation/Stacks/Common/CommonStackComponents';
@@ -68,12 +66,6 @@ const UserProfileScreenBaseInner = ({data, refetch, isLoading}: Props) => {
   const {preRegistrationMode} = usePreRegistration();
   const {oobeCompleted} = useOobe();
   const isSelf = data?.header.userID === currentUserID;
-  const onEditProfilePress = useCallback(() => {
-    if (!data) {
-      return;
-    }
-    commonNavigation.push(CommonStackComponents.userProfileEditScreen, {user: data});
-  }, [commonNavigation, data]);
   const {refreshing, setRefreshing, onRefresh} = useRefresh({
     refresh: useCallback(async () => {
       const refreshes = [
@@ -89,7 +81,6 @@ const UserProfileScreenBaseInner = ({data, refetch, isLoading}: Props) => {
       return (
         <View>
           <MaterialHeaderButtons left>
-            <Item title={'Edit'} iconName={AppIcons.edituser} onPress={onEditProfilePress} />
             <UserProfileSelfActionsMenu userID={data.header.userID} />
           </MaterialHeaderButtons>
         </View>
@@ -107,7 +98,7 @@ const UserProfileScreenBaseInner = ({data, refetch, isLoading}: Props) => {
         </MaterialHeaderButtons>
       </View>
     );
-  }, [data, isSelf, isMuted, isBlocked, onEditProfilePress]);
+  }, [data, isSelf, isMuted, isBlocked]);
 
   useEffect(() => {
     commonNavigation.setOptions({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Edit on your own profile is already available via the floating action button. This removes the duplicate header Edit button so the screen matches that pattern.

The header still has the actions menu (Share / Help). Other users' profiles are unchanged.

Fixes #488
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09a2c2ec-6667-48bd-8abf-83506cdd400f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09a2c2ec-6667-48bd-8abf-83506cdd400f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

