### PR TITLE
Allow performer profile create/edit during pre-registration

### DIFF
--- a/src/Screens/Performer/PerformerCreateScreen.tsx
+++ b/src/Screens/Performer/PerformerCreateScreen.tsx
@@ -12,20 +12,17 @@ import {CommonStackComponents} from '#src/Navigation/Stacks/Common/CommonStackCo
 import {MainStackParamList} from '#src/Navigation/Stacks/Main/MainStackComponents';
 import {usePerformerUpsertMutation} from '#src/Queries/Performer/PerformerMutations';
 import {DisabledFeatureScreen} from '#src/Screens/Checkpoint/DisabledFeatureScreen';
-import {PreRegistrationScreen} from '#src/Screens/Checkpoint/PreRegistrationScreen';
 import {EventData, PerformerData, PerformerUploadData} from '#src/Structs/ControllerStructs';
 
 type Props = StackScreenProps<MainStackParamList, CommonStackComponents.performerCreateScreen>;
 
 export const PerformerCreateScreen = (props: Props) => {
   return (
-    <PreRegistrationScreen helpScreen={CommonStackComponents.performerHelpScreen}>
-      <DisabledFeatureScreen
-        feature={SwiftarrFeature.performers}
-        urlPath={`/performer/shadow/addtoevent/${props.route.params.eventID}`}>
-        <PerformerCreateScreenInner {...props} />
-      </DisabledFeatureScreen>
-    </PreRegistrationScreen>
+    <DisabledFeatureScreen
+      feature={SwiftarrFeature.performers}
+      urlPath={`/performer/shadow/addtoevent/${props.route.params.eventID}`}>
+      <PerformerCreateScreenInner {...props} />
+    </DisabledFeatureScreen>
   );
 };
 

--- a/src/Screens/Performer/PerformerEditScreen.tsx
+++ b/src/Screens/Performer/PerformerEditScreen.tsx
@@ -11,20 +11,17 @@ import {SwiftarrFeature} from '#src/Enums/AppFeatures';
 import {CommonStackComponents, CommonStackParamList} from '#src/Navigation/Stacks/Common/CommonStackComponents';
 import {usePerformerUpsertMutation} from '#src/Queries/Performer/PerformerMutations';
 import {DisabledFeatureScreen} from '#src/Screens/Checkpoint/DisabledFeatureScreen';
-import {PreRegistrationScreen} from '#src/Screens/Checkpoint/PreRegistrationScreen';
 import {EventData, PerformerData, PerformerUploadData} from '#src/Structs/ControllerStructs';
 
 type Props = StackScreenProps<CommonStackParamList, CommonStackComponents.performerEditScreen>;
 
 export const PerformerEditScreen = (props: Props) => {
   return (
-    <PreRegistrationScreen helpScreen={CommonStackComponents.performerHelpScreen}>
-      <DisabledFeatureScreen
-        feature={SwiftarrFeature.performers}
-        urlPath={`/performer/shadow/addtoevent/${props.route.params.eventID}`}>
-        <PerformerEditScreenInner {...props} />
-      </DisabledFeatureScreen>
-    </PreRegistrationScreen>
+    <DisabledFeatureScreen
+      feature={SwiftarrFeature.performers}
+      urlPath={`/performer/shadow/addtoevent/${props.route.params.eventID}`}>
+      <PerformerEditScreenInner {...props} />
+    </DisabledFeatureScreen>
   );
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/jocosocial/tricordarr/issues/492

## Summary

Shadow Cruise organizers are expected to create performer bios **before sailing**. Help text already says this (`PreRegistrationHelpScreen`, `ShadowPerformerProfilesHelpTopicView`), and **Set Organizer** is already enabled in pre-registration.

Create and edit were still wrapped in `PreRegistrationScreen`, so those screens showed the “limited features” placeholder instead of the form.

## Change

- Remove the `PreRegistrationScreen` checkpoint from `PerformerCreateScreen` and `PerformerEditScreen`.
- Keep `DisabledFeatureScreen` so a server-side performers disable still applies.

Delete/attach on `EventAddPerformerScreen` was already available in pre-registration (no checkpoint there).

## How to test

1. Enable pre-registration mode.
2. Open a Shadow Event → Actions → **Set Organizer**.
3. **Create Profile** should show the performer form (not the pre-registration placeholder).
4. After creating, **View/Edit** and **Delete** should still work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c24f855-8e7f-4222-a10c-299adafe4937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c24f855-8e7f-4222-a10c-299adafe4937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

