### PR TITLE
Add Reply action to forum posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm run typecheck
 npm run lint
 ```
 
+Note that `npm test` is not currently green on a clean checkout: `TestDateTime`,
+`TestNewDayMinuteCalculator` and `TestScheduleMarker` fail (5 tests), apparently
+timezone-dependent. Compare against a clean tree before assuming you caused a failure.
+
 End-to-end flows live in `__tests__/e2e/` and run on
 [Maestro](https://maestro.mobile.dev). Install it with the official installer
 (`curl -Ls "https://get.maestro.mobile.dev" | bash`), which needs a JDK and drops into

--- a/README.md
+++ b/README.md
@@ -20,4 +20,51 @@ npx pod-install
 npx expo run:ios --scheme Development # or Production, --device "Simulator Name"
 ```
 
-See [Docs](./docs/) for more.
+Testing
+-------
+
+There is no CI for tests yet — lint runs on push, but unit and end-to-end tests only run
+where you run them. Please exercise both locally before opening a PR.
+
+```bash
+npm test        # unit tests (Jest)
+npm run typecheck
+npm run lint
+```
+
+End-to-end flows live in `__tests__/e2e/` and run on
+[Maestro](https://maestro.mobile.dev). Install it with the official installer
+(`curl -Ls "https://get.maestro.mobile.dev" | bash`), which needs a JDK and drops into
+`~/.maestro/bin`. The Homebrew formula fails if your Command Line Tools are older than
+your Xcode.
+
+Flows drive a real app against a real server, so before running them you need a
+[swiftarr](https://github.com/jocosocial/swiftarr) instance, the app built and installed
+on a simulator or emulator, Metro running (`npx expo start --dev-client`), and the app
+signed in. The `Emulator` server preset points at port `3050`, so set `SWIFTARR_PORT=3050`
+in your swiftarr `development.env` if you want that preset to work.
+
+```bash
+# iOS
+maestro test -e APP_ID=com.grantcohoe.tricordarr __tests__/e2e/Forum/ForumPostReply.yaml
+
+# Android — note the different app ID
+maestro test -e APP_ID=com.tricordarr __tests__/e2e/Forum/ForumPostReply.yaml
+
+# With both a simulator and an emulator running, name the target
+maestro --device emulator-5554 test -e APP_ID=com.tricordarr <flow>.yaml
+```
+
+Two things that will save you time. On Android, use an AVD built from a **non-Play**
+system image (`google_apis`, not `google_apis_playstore`); Play images set
+`ro.adb.secure=1` and pop an "Allow USB debugging" dialog that nothing can dismiss
+programmatically, because every tool you would use goes through adb. Also disable the
+system handwriting overlay, which otherwise swallows the first `inputText`:
+`adb shell settings put secure stylus_handwriting_enabled 0`.
+
+A flow that passes is not automatically a flow that tests anything. Before trusting a new
+one, break the code it covers and confirm it fails — assertions that match any visible
+text will happily match rendered content instead of the widget you meant.
+
+See [docs/Testing.md](./docs/Testing.md) for `testID` conventions and
+[Docs](./docs/) for more.

--- a/__tests__/e2e/Forum/ForumPostReply.yaml
+++ b/__tests__/e2e/Forum/ForumPostReply.yaml
@@ -1,0 +1,30 @@
+# Reply appends an @mention of the post's author to the thread composer.
+#
+# Swiftarr has no structural reply relation for forum posts; the @mention is what notifies
+# the author. It only counts the mention when the @ follows whitespace or the start of the
+# string (`(?<!\S)@` in ContentFilterable.getMentionsSet), so the separator space between
+# text already typed and the inserted mention is the thing actually under test.
+#
+# Precondition: signed in and viewing a forum thread whose first post is by another user.
+# Run ../OOBE/Login.yaml first, then navigate to such a thread. Reply is deliberately
+# absent on your own posts, so index 0 must not be yours.
+appId: ${APP_ID}
+---
+- tapOn:
+    id: 'contentPostText-input'
+- eraseText
+- inputText: 'hello'
+- assertVisible: '(?s).*hello.*'
+# The keyboard must be down before the long-press. With it up, the post's centre sits
+# behind it and the press lands on the keyboard, which silently dismisses it instead of
+# opening the menu.
+- hideKeyboard
+# Long-press by id rather than by text: the post's text selector resolves to an oversized
+# container whose centre is empty space.
+- longPressOn:
+    id: 'forumPost-message'
+    index: 0
+- assertVisible: 'Reply'
+- tapOn: 'Reply'
+# Separator space preserved, existing text untouched, mention appended after it.
+- assertVisible: '(?s).*hello @.*'

--- a/__tests__/e2e/Forum/ForumPostReply.yaml
+++ b/__tests__/e2e/Forum/ForumPostReply.yaml
@@ -6,9 +6,12 @@
 # string (`(?<!\S)@` in ContentFilterable.getMentionsSet), so the separator space in the
 # second scenario is the thing actually under test there.
 #
-# Precondition: signed in (run ../OOBE/Login.yaml first). FORUM_THREAD must name a thread
-# in FORUM_CATEGORY whose first post is by another user — Reply is deliberately absent on
-# your own posts, so the post at index 0 must not be yours.
+# Precondition: the app is signed in. ../OOBE/Login.yaml is meant to get you there but is
+# currently unreliable — its fixed `repeat: 7` scrolls do not reach the agree button, and
+# SetupApp.yaml's iOS branch leaves the app closed — so sign in by hand for now.
+#
+# FORUM_THREAD must name a thread in FORUM_CATEGORY whose first post is by another user:
+# Reply is deliberately absent on your own posts, so the post at index 0 must not be yours.
 appId: ${APP_ID}
 env:
   FORUM_CATEGORY: 'General'

--- a/__tests__/e2e/Forum/ForumPostReply.yaml
+++ b/__tests__/e2e/Forum/ForumPostReply.yaml
@@ -5,11 +5,22 @@
 # string (`(?<!\S)@` in ContentFilterable.getMentionsSet), so the separator space between
 # text already typed and the inserted mention is the thing actually under test.
 #
-# Precondition: signed in and viewing a forum thread whose first post is by another user.
-# Run ../OOBE/Login.yaml first, then navigate to such a thread. Reply is deliberately
-# absent on your own posts, so index 0 must not be yours.
+# Precondition: signed in (run ../OOBE/Login.yaml first). FORUM_THREAD must name a thread
+# in FORUM_CATEGORY whose first post is by another user — Reply is deliberately absent on
+# your own posts, so the post at index 0 must not be yours.
 appId: ${APP_ID}
+env:
+  FORUM_CATEGORY: 'General'
+  FORUM_THREAD: 'Reply caret test thread'
 ---
+# Tab labels bundle icon glyphs in with the text ("<glyph>, <glyph>, Forums, Forums"), so
+# every text selector here needs wildcards rather than a bare literal.
+- tapOn: '(?s).*Forums.*'
+- tapOn: '(?s).*${FORUM_CATEGORY}.*'
+- tapOn: '(?s).*${FORUM_THREAD}.*'
+- assertVisible:
+    id: 'contentPostText-input'
+# Text already in the composer must survive, and the mention must land after it.
 - tapOn:
     id: 'contentPostText-input'
 - eraseText

--- a/__tests__/e2e/Forum/ForumPostReply.yaml
+++ b/__tests__/e2e/Forum/ForumPostReply.yaml
@@ -20,7 +20,13 @@ env:
 # keyboard is up, and an open keyboard covers the bottom tab bar, so the tab tap below
 # would otherwise land on the keyboard and never navigate. No clearState: the session is
 # reused so the flow stays signed in.
-- launchApp
+#
+# The launch argument suppresses the Expo dev-menu sheet, which otherwise covers the app
+# on the first launch after app data is cleared and swallows the taps below. Same argument
+# SetupApp.yaml passes.
+- launchApp:
+    arguments:
+      '-EXDevMenuIsOnboardingFinished': true
 # Tab labels bundle icon glyphs in with the text ("<glyph>, <glyph>, Forums, Forums"), so
 # every text selector here needs wildcards rather than a bare literal.
 - tapOn: '(?s).*Forums.*'

--- a/__tests__/e2e/Forum/ForumPostReply.yaml
+++ b/__tests__/e2e/Forum/ForumPostReply.yaml
@@ -48,15 +48,22 @@ env:
 - tapOn: 'Reply'
 # Deliberately no tap on the composer first — that is the whole point of this scenario.
 - inputText: ${MARKER}
-- assertVisible: '(?s).*@.*${MARKER}.*'
+# Every assertion here is scoped to the composer by id. An unscoped text assertion also
+# matches the posts rendered in the thread, so it would pass even if Reply did nothing.
+- assertVisible:
+    id: 'contentPostText-input'
+    text: '(?s).*@.*${MARKER}.*'
 
 # Scenario 2 — replying while part-way through a sentence. Existing text must survive and
-# the mention must land after it, separated by a space.
+# the mention must land after it, separated by a space. The typed text carries the marker
+# so it cannot collide with post content.
 - eraseText
-- inputText: 'hello'
+- inputText: '${MARKER}pre'
 - hideKeyboard
 - longPressOn:
     id: 'forumPost-message'
     index: 0
 - tapOn: 'Reply'
-- assertVisible: '(?s).*hello @.*'
+- assertVisible:
+    id: 'contentPostText-input'
+    text: '(?s).*${MARKER}pre @.*'

--- a/__tests__/e2e/Forum/ForumPostReply.yaml
+++ b/__tests__/e2e/Forum/ForumPostReply.yaml
@@ -1,9 +1,10 @@
-# Reply appends an @mention of the post's author to the thread composer.
+# Reply appends an @mention of the post's author to the thread composer and leaves the
+# user ready to type.
 #
 # Swiftarr has no structural reply relation for forum posts; the @mention is what notifies
 # the author. It only counts the mention when the @ follows whitespace or the start of the
-# string (`(?<!\S)@` in ContentFilterable.getMentionsSet), so the separator space between
-# text already typed and the inserted mention is the thing actually under test.
+# string (`(?<!\S)@` in ContentFilterable.getMentionsSet), so the separator space in the
+# second scenario is the thing actually under test there.
 #
 # Precondition: signed in (run ../OOBE/Login.yaml first). FORUM_THREAD must name a thread
 # in FORUM_CATEGORY whose first post is by another user — Reply is deliberately absent on
@@ -12,7 +13,14 @@ appId: ${APP_ID}
 env:
   FORUM_CATEGORY: 'General'
   FORUM_THREAD: 'Reply caret test thread'
+  # Marker typed into the composer. Distinctive so assertions can't match post text.
+  MARKER: 'zzq'
 ---
+# Start from a known screen. `hideKeyboard` is not usable here because it errors when no
+# keyboard is up, and an open keyboard covers the bottom tab bar, so the tab tap below
+# would otherwise land on the keyboard and never navigate. No clearState: the session is
+# reused so the flow stays signed in.
+- launchApp
 # Tab labels bundle icon glyphs in with the text ("<glyph>, <glyph>, Forums, Forums"), so
 # every text selector here needs wildcards rather than a bare literal.
 - tapOn: '(?s).*Forums.*'
@@ -20,12 +28,13 @@ env:
 - tapOn: '(?s).*${FORUM_THREAD}.*'
 - assertVisible:
     id: 'contentPostText-input'
-# Text already in the composer must survive, and the mention must land after it.
+
+# Scenario 1 — the common one. Long-press a post, hit Reply, start typing. Opening the
+# actions menu blurs the composer, so Reply has to restore focus and put the caret after
+# the mention. Without that the keystrokes below go nowhere.
 - tapOn:
     id: 'contentPostText-input'
 - eraseText
-- inputText: 'hello'
-- assertVisible: '(?s).*hello.*'
 # The keyboard must be down before the long-press. With it up, the post's centre sits
 # behind it and the press lands on the keyboard, which silently dismisses it instead of
 # opening the menu.
@@ -37,5 +46,17 @@ env:
     index: 0
 - assertVisible: 'Reply'
 - tapOn: 'Reply'
-# Separator space preserved, existing text untouched, mention appended after it.
+# Deliberately no tap on the composer first — that is the whole point of this scenario.
+- inputText: ${MARKER}
+- assertVisible: '(?s).*@.*${MARKER}.*'
+
+# Scenario 2 — replying while part-way through a sentence. Existing text must survive and
+# the mention must land after it, separated by a space.
+- eraseText
+- inputText: 'hello'
+- hideKeyboard
+- longPressOn:
+    id: 'forumPost-message'
+    index: 0
+- tapOn: 'Reply'
 - assertVisible: '(?s).*hello @.*'

--- a/__tests__/e2e/Forum/ForumPostReply.yaml
+++ b/__tests__/e2e/Forum/ForumPostReply.yaml
@@ -30,8 +30,16 @@ env:
 - launchApp:
     arguments:
       '-EXDevMenuIsOnboardingFinished': true
+# Relaunching makes the dev client refetch the JS bundle, so wait for the tab bar to
+# actually exist before tapping it. Android is slow enough here that tapping immediately
+# fails with a bare "Element not found"; iOS usually wins the race, which is exactly the
+# kind of difference that makes this flaky rather than broken.
+#
 # Tab labels bundle icon glyphs in with the text ("<glyph>, <glyph>, Forums, Forums"), so
 # every text selector here needs wildcards rather than a bare literal.
+- extendedWaitUntil:
+    visible: '(?s).*Forums.*'
+    timeout: 120000
 - tapOn: '(?s).*Forums.*'
 - tapOn: '(?s).*${FORUM_CATEGORY}.*'
 - tapOn: '(?s).*${FORUM_THREAD}.*'

--- a/__tests__/unit/TestMentionText.ts
+++ b/__tests__/unit/TestMentionText.ts
@@ -16,6 +16,24 @@ describe('isMentioned', () => {
     expect(isMentioned('hello @grantcohoe', 'grant')).toBe(false);
   });
 
+  it('ignores trailing punctuation', () => {
+    expect(isMentioned('hi @grant, how are you', 'grant')).toBe(true);
+    expect(isMentioned('ask @grant.', 'grant')).toBe(true);
+    expect(isMentioned('ask @grant?', 'grant')).toBe(true);
+    expect(isMentioned('(cc @grant)', 'grant')).toBe(true);
+  });
+
+  it('keeps punctuation that is part of the username', () => {
+    expect(isMentioned('hi @grant.cohoe, hello', 'grant.cohoe')).toBe(true);
+    // Stripping the trailing dot must not collapse this onto a shorter name.
+    expect(isMentioned('hi @grant.cohoe.', 'grant')).toBe(false);
+  });
+
+  it('does not match when the @ is not preceded by whitespace', () => {
+    // Swiftarr's (?<!\S)@ rule means this is not a mention, so it must not dedupe.
+    expect(isMentioned('mail me at foo@grant', 'grant')).toBe(false);
+  });
+
   it('does not match the username without an @', () => {
     expect(isMentioned('hello grant', 'grant')).toBe(false);
   });
@@ -52,5 +70,10 @@ describe('appendMention', () => {
   it('supports the punctuation Swiftarr allows in usernames', () => {
     expect(appendMention('hi', 'grant.cohoe')).toBe('hi @grant.cohoe ');
     expect(appendMention('@grant.cohoe hi', 'grant.cohoe')).toBe('@grant.cohoe hi');
+  });
+
+  it('does not re-add a user mentioned before punctuation', () => {
+    expect(appendMention('hi @grant, ok', 'grant')).toBe('hi @grant, ok');
+    expect(appendMention('thanks @grant!', 'grant')).toBe('thanks @grant!');
   });
 });

--- a/__tests__/unit/TestMentionText.ts
+++ b/__tests__/unit/TestMentionText.ts
@@ -1,0 +1,56 @@
+import {appendMention, isMentioned} from '#src/Libraries/StringUtils';
+
+describe('isMentioned', () => {
+  it('finds a mention as a standalone word', () => {
+    expect(isMentioned('@grant hello', 'grant')).toBe(true);
+    expect(isMentioned('hello @grant', 'grant')).toBe(true);
+    expect(isMentioned('hello @grant there', 'grant')).toBe(true);
+  });
+
+  it('matches case-insensitively like Swiftarr does', () => {
+    expect(isMentioned('hello @Grant', 'grant')).toBe(true);
+    expect(isMentioned('hello @grant', 'GRANT')).toBe(true);
+  });
+
+  it('does not match a longer username that starts with the same text', () => {
+    expect(isMentioned('hello @grantcohoe', 'grant')).toBe(false);
+  });
+
+  it('does not match the username without an @', () => {
+    expect(isMentioned('hello grant', 'grant')).toBe(false);
+  });
+
+  it('handles empty text', () => {
+    expect(isMentioned('', 'grant')).toBe(false);
+  });
+});
+
+describe('appendMention', () => {
+  it('mentions into an empty composer', () => {
+    expect(appendMention('', 'grant')).toBe('@grant ');
+  });
+
+  it('separates the mention from existing text', () => {
+    // Swiftarr's getMentionsSet requires whitespace before the @.
+    expect(appendMention('hello', 'grant')).toBe('hello @grant ');
+  });
+
+  it('does not double the separator when the text already ends in whitespace', () => {
+    expect(appendMention('hello ', 'grant')).toBe('hello @grant ');
+    expect(appendMention('hello\n', 'grant')).toBe('hello\n@grant ');
+  });
+
+  it('leaves the text alone when that user is already mentioned', () => {
+    expect(appendMention('@grant hello', 'grant')).toBe('@grant hello');
+    expect(appendMention('@grant ', 'grant')).toBe('@grant ');
+  });
+
+  it('still mentions a different user', () => {
+    expect(appendMention('@grant hello', 'cohoe')).toBe('@grant hello @cohoe ');
+  });
+
+  it('supports the punctuation Swiftarr allows in usernames', () => {
+    expect(appendMention('hi', 'grant.cohoe')).toBe('hi @grant.cohoe ');
+    expect(appendMention('@grant.cohoe hi', 'grant.cohoe')).toBe('@grant.cohoe hi');
+  });
+});

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -20,6 +20,9 @@ Kinds:
 - `slider` — `SliderField`
 - `fab` — FABs and FAB group actions
 - `headerButton` — header `Item`s
+- `message` — long-pressable message bubbles (`MessageView`). Unlike the others this is
+  not unique on screen; every message in a list shares the value, so flows pick one with
+  Maestro's `index`.
 
 Examples: `loginUsername-input`, `loginSubmit-button`, `serverChoice-button`, `oobeNext-button`, `seamailCreate-fab`, `headerEdit-headerButton`, `forumThreadFavorite-button`.
 

--- a/src/Components/Forms/ContentPostForm.tsx
+++ b/src/Components/Forms/ContentPostForm.tsx
@@ -1,6 +1,6 @@
 import {Formik, FormikHelpers, FormikProps, useFormikContext} from 'formik';
 import React, {useEffect} from 'react';
-import {ScrollView, StyleSheet, View} from 'react-native';
+import {ScrollView, StyleSheet, TextInput, View} from 'react-native';
 import {IconButton} from 'react-native-paper';
 import * as Yup from 'yup';
 
@@ -58,6 +58,8 @@ interface ContentPostFormProps {
   maxPhotos?: number;
   initialValues?: PostContentData;
   disabled?: boolean;
+  /** Receives the text input, so callers can focus it after writing into the form. */
+  inputRef?: React.MutableRefObject<TextInput | null>;
 }
 
 // https://formik.org/docs/guides/react-native
@@ -71,6 +73,7 @@ export const ContentPostForm = ({
   maxPhotos = 1,
   initialValues,
   disabled = false,
+  inputRef,
 }: ContentPostFormProps) => {
   const {commonStyles} = useStyles();
   const {asPrivilegedUser} = useElevation();
@@ -198,7 +201,12 @@ export const ContentPostForm = ({
                   />
                 </View>
                 <View style={styles.inputWrapperView}>
-                  <MentionTextField name={'text'} testID={'contentPostText-input'} style={styles.input} />
+                  <MentionTextField
+                    name={'text'}
+                    testID={'contentPostText-input'}
+                    style={styles.input}
+                    inputRef={inputRef}
+                  />
                   <ContentInsertPhotosView />
                 </View>
                 <View style={styles.inputWrapperViewSide}>

--- a/src/Components/Forms/Fields/MentionTextField.tsx
+++ b/src/Components/Forms/Fields/MentionTextField.tsx
@@ -11,12 +11,18 @@ interface MentionTextFieldProps {
   name: string;
   testID: string;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Receives the underlying TextInput so callers can focus it or move the caret. Needed
+   * when something outside the form writes into the field, since the user is otherwise
+   * left with text they cannot type after.
+   */
+  inputRef?: React.MutableRefObject<TextInput | null>;
 }
 
 export const MentionTextField = (props: MentionTextFieldProps) => {
   const {commonStyles} = useStyles();
   const [field, _, helpers] = useField<string>(props.name);
-  const textInputRef = useRef<TextInput>(null);
+  const textInputRef = useRef<TextInput | null>(null);
   const pendingMentionInsertionRef = useRef<boolean>(false);
 
   const triggersConfig: TriggersConfig<'mention' | 'hashtag'> = useMemo(
@@ -108,7 +114,12 @@ export const MentionTextField = (props: MentionTextFieldProps) => {
       {mentionTriggerProps && <ContentPostMentionSuggestionsView {...mentionTriggerProps} />}
       <TextInput
         testID={props.testID}
-        ref={textInputRef}
+        ref={node => {
+          textInputRef.current = node;
+          if (props.inputRef) {
+            props.inputRef.current = node;
+          }
+        }}
         // The textInputProps provides onChangeText and onSelectionChange.
         {...textInputProps}
         style={props.style}

--- a/src/Components/Forms/Fields/MentionTextField.tsx
+++ b/src/Components/Forms/Fields/MentionTextField.tsx
@@ -25,6 +25,22 @@ export const MentionTextField = (props: MentionTextFieldProps) => {
   const textInputRef = useRef<TextInput | null>(null);
   const pendingMentionInsertionRef = useRef<boolean>(false);
 
+  /**
+   * Fans the input out to the caller's ref as well as the local one. Stable so React
+   * doesn't detach and reattach it on every render, which would leave the caller's ref
+   * momentarily null.
+   */
+  const callerInputRef = props.inputRef;
+  const setInputRefs = useCallback(
+    (node: TextInput | null) => {
+      textInputRef.current = node;
+      if (callerInputRef) {
+        callerInputRef.current = node;
+      }
+    },
+    [callerInputRef],
+  );
+
   const triggersConfig: TriggersConfig<'mention' | 'hashtag'> = useMemo(
     () => ({
       mention: {
@@ -114,12 +130,7 @@ export const MentionTextField = (props: MentionTextFieldProps) => {
       {mentionTriggerProps && <ContentPostMentionSuggestionsView {...mentionTriggerProps} />}
       <TextInput
         testID={props.testID}
-        ref={node => {
-          textInputRef.current = node;
-          if (props.inputRef) {
-            props.inputRef.current = node;
-          }
-        }}
+        ref={setInputRefs}
         // The textInputProps provides onChangeText and onSelectionChange.
         {...textInputProps}
         style={props.style}

--- a/src/Components/Lists/Items/Forum/ForumPostListItem.tsx
+++ b/src/Components/Lists/Items/Forum/ForumPostListItem.tsx
@@ -78,6 +78,7 @@ const ForumPostListItemInternal = ({
       </MessageAvatarContainerView>
       <MessageViewContainer>
         <MessageView
+          testID={'forumPost-message'}
           author={postData.author}
           text={postData.text}
           timestamp={new Date(postData.createdAt)}

--- a/src/Components/Menus/Forum/ForumPostActionsMenu.tsx
+++ b/src/Components/Menus/Forum/ForumPostActionsMenu.tsx
@@ -6,9 +6,11 @@ import {ForumPostActionsFavoriteItem} from '#src/Components/Menus/Forum/Items/Fo
 import {ForumPostActionsModerateItem} from '#src/Components/Menus/Forum/Items/ForumPostActionsModerateItem';
 import {ForumPostActionsPinItem} from '#src/Components/Menus/Forum/Items/ForumPostActionsPinItem';
 import {ForumPostActionsReactionItem} from '#src/Components/Menus/Forum/Items/ForumPostActionsReactionItem';
+import {ForumPostActionsReplyItem} from '#src/Components/Menus/Forum/Items/ForumPostActionsReplyItem';
 import {ForumPostActionsReportItem} from '#src/Components/Menus/Forum/Items/ForumPostActionsReportItem';
 import {ForumPostActionsShowThreadItem} from '#src/Components/Menus/Forum/Items/ForumPostActionsShowThreadItem';
 import {ShareMenuItem} from '#src/Components/Menus/Items/ShareMenuItem';
+import {useForumComposer} from '#src/Context/Contexts/ForumComposerContext';
 import {useSession} from '#src/Context/Contexts/SessionContext';
 import {AppIcons} from '#src/Enums/Icons';
 import {useClipboard} from '#src/Hooks/useClipboard';
@@ -40,6 +42,12 @@ export const ForumPostActionsMenu = ({
   // Apparently this doesn't get to be available in the sub items? That's annoying.
   const commonNavigation = useCommonStack();
   const {setString} = useClipboard();
+  // Undefined outside a thread composer. Same portal caveat as the navigation above, so
+  // read it here and pass the callback down.
+  const composer = useForumComposer();
+  // Replying to yourself would tag yourself, and Swiftarr drops self-mentions
+  // (`userDidntMentionSelf` in ForumController), so there is nothing to gain.
+  const onReply = composer && !bySelf ? composer.mentionUser : undefined;
 
   /**
    * closeMenu comes from the instance established in MessageView so we need to drill
@@ -47,9 +55,12 @@ export const ForumPostActionsMenu = ({
    */
   return (
     <Menu visible={visible} onDismiss={closeMenu} anchor={anchor}>
-      {enableShowInThread && (
+      {(onReply || enableShowInThread) && (
         <>
-          <ForumPostActionsShowThreadItem forumPost={forumPost} closeMenu={closeMenu} navigation={commonNavigation} />
+          {onReply && <ForumPostActionsReplyItem forumPost={forumPost} closeMenu={closeMenu} onReply={onReply} />}
+          {enableShowInThread && (
+            <ForumPostActionsShowThreadItem forumPost={forumPost} closeMenu={closeMenu} navigation={commonNavigation} />
+          )}
           <Divider bold={true} />
         </>
       )}

--- a/src/Components/Menus/Forum/Items/ForumPostActionsReplyItem.tsx
+++ b/src/Components/Menus/Forum/Items/ForumPostActionsReplyItem.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {Menu} from 'react-native-paper';
+
+import {AppIcons} from '#src/Enums/Icons';
+import {PostData} from '#src/Structs/ControllerStructs';
+
+interface ForumPostActionsReplyItemProps {
+  forumPost: PostData;
+  closeMenu: () => void;
+  /**
+   * Appends the mention to the thread composer. Supplied by the menu rather than read
+   * from context here, because this item remounts inside Portal.Host.
+   */
+  onReply: (username: string) => void;
+}
+
+/**
+ * Starts a reply to a post by @mentioning its author in the thread composer.
+ *
+ * Swiftarr has no structural reply relation for forum posts; the @mention is what
+ * generates the author's notification (`NotificationType.forumMention`).
+ */
+export const ForumPostActionsReplyItem = ({forumPost, closeMenu, onReply}: ForumPostActionsReplyItemProps) => {
+  const onPress = () => {
+    closeMenu();
+    onReply(forumPost.author.username);
+  };
+  return <Menu.Item dense={false} leadingIcon={AppIcons.reply} title={'Reply'} onPress={onPress} />;
+};

--- a/src/Components/Views/MessageView.tsx
+++ b/src/Components/Views/MessageView.tsx
@@ -34,6 +34,12 @@ interface MessageViewProps {
   isBookmarked?: boolean;
   isPinned?: boolean;
   renderActionsMenu: (props: MessageViewActionsMenuProps) => ReactNode;
+  /**
+   * Applied to the pressable that opens the actions menu, so E2E flows can long-press a
+   * message by id instead of by screen coordinates. Every message in a list shares the
+   * value, so flows select a particular one with Maestro's `index`.
+   */
+  testID?: string;
 }
 
 /**
@@ -56,6 +62,7 @@ export const MessageView = ({
   isBookmarked,
   isPinned,
   renderActionsMenu,
+  testID,
 }: MessageViewProps) => {
   const {commonStyles} = useStyles();
   const {visible: menuVisible, openMenu, closeMenu} = useMenu();
@@ -112,6 +119,7 @@ export const MessageView = ({
   return (
     <View style={styles.messageView}>
       <TouchableOpacity
+        testID={testID}
         style={styles.opacity}
         activeOpacity={1}
         /**

--- a/src/Context/Contexts/ForumComposerContext.ts
+++ b/src/Context/Contexts/ForumComposerContext.ts
@@ -1,0 +1,23 @@
+import {createContext, useContext} from 'react';
+
+export interface ForumComposerContextType {
+  /**
+   * Appends an @mention of the given username to the thread composer, leaving any text
+   * the user has already typed in place.
+   */
+  mentionUser: (username: string) => void;
+}
+
+export const ForumComposerContext = createContext<ForumComposerContextType | undefined>(undefined);
+
+/**
+ * Controls for the forum thread composer, or undefined when there is no composer on
+ * screen. Undefined in post lists outside a thread (mentions, search, favorites) and in
+ * a locked thread the user cannot post to, so callers can use it to decide whether to
+ * offer composer-dependent actions such as Reply.
+ *
+ * React Native Paper menu items remount inside `Portal.Host` and therefore cannot read
+ * this context. Call this hook from the menu itself and pass what you need down as a
+ * prop. See `docs/Navigation.md`.
+ */
+export const useForumComposer = () => useContext(ForumComposerContext);

--- a/src/Context/Providers/ForumComposerProvider.tsx
+++ b/src/Context/Providers/ForumComposerProvider.tsx
@@ -1,5 +1,6 @@
 import {FormikProps} from 'formik';
 import React, {PropsWithChildren, useMemo} from 'react';
+import {TextInput} from 'react-native';
 
 import {ForumComposerContext, ForumComposerContextType} from '#src/Context/Contexts/ForumComposerContext';
 import {appendMention} from '#src/Libraries/StringUtils';
@@ -8,6 +9,8 @@ import {PostContentData} from '#src/Structs/ControllerStructs';
 interface ForumComposerProviderProps {
   /** Formik ref for the thread's ContentPostForm. */
   formRef: React.RefObject<FormikProps<PostContentData> | null>;
+  /** Text input for that same form, so a mention can leave the user ready to type. */
+  inputRef: React.MutableRefObject<TextInput | null>;
   /** False when the thread has no composer, which makes the context undefined. */
   enabled: boolean;
 }
@@ -20,7 +23,12 @@ interface ForumComposerProviderProps {
  * Formik refreshes `innerRef` on every render, so `formRef.current.values` is the live
  * composer content rather than a snapshot from when this provider mounted.
  */
-export const ForumComposerProvider = ({formRef, enabled, children}: PropsWithChildren<ForumComposerProviderProps>) => {
+export const ForumComposerProvider = ({
+  formRef,
+  inputRef,
+  enabled,
+  children,
+}: PropsWithChildren<ForumComposerProviderProps>) => {
   const value = useMemo<ForumComposerContextType | undefined>(() => {
     if (!enabled) {
       return undefined;
@@ -31,10 +39,19 @@ export const ForumComposerProvider = ({formRef, enabled, children}: PropsWithChi
         if (!form) {
           return;
         }
-        form.setFieldValue('text', appendMention(form.values.text, username));
+        const text = appendMention(form.values.text, username);
+        form.setFieldValue('text', text);
+        // Opening the actions menu dismissed the keyboard and blurred the composer, so
+        // without this the user is left looking at a mention they cannot type after.
+        // Deferred a frame so focus lands after the new value has been applied, and the
+        // caret is placed explicitly rather than wherever the field was last left.
+        requestAnimationFrame(() => {
+          inputRef.current?.focus();
+          inputRef.current?.setNativeProps({selection: {start: text.length, end: text.length}});
+        });
       },
     };
-  }, [enabled, formRef]);
+  }, [enabled, formRef, inputRef]);
 
   return <ForumComposerContext.Provider value={value}>{children}</ForumComposerContext.Provider>;
 };

--- a/src/Context/Providers/ForumComposerProvider.tsx
+++ b/src/Context/Providers/ForumComposerProvider.tsx
@@ -45,11 +45,17 @@ export const ForumComposerProvider = ({
         // Matches ElevationPrivilegeSync in ContentPostForm. (`no-void` rules out marking
         // it with the void operator.)
         form.setFieldValue('text', text);
-        // Opening the actions menu dismissed the keyboard and blurred the composer, so
-        // without this the user is left looking at a mention they cannot type after.
-        // Deferred a frame so focus lands after the new value has been applied, and the
+        // Opening the actions menu leaves the composer unusable, so without this the user
+        // is looking at a mention they cannot type after. The two platforms get there
+        // differently: iOS fully blurs the field, while Android keeps focus and the caret
+        // but closes the soft keyboard. `focus()` alone fixes iOS but is a no-op on
+        // Android, where the field never lost focus — hence the explicit blur first, which
+        // forces the keyboard back up on both.
+        //
+        // Deferred a frame so this lands after the new value has been applied, and the
         // caret is placed explicitly rather than wherever the field was last left.
         requestAnimationFrame(() => {
+          inputRef.current?.blur();
           inputRef.current?.focus();
           // setSelection rather than setNativeProps: this app runs the new architecture,
           // where setNativeProps goes through legacy viewConfig attribute filtering.

--- a/src/Context/Providers/ForumComposerProvider.tsx
+++ b/src/Context/Providers/ForumComposerProvider.tsx
@@ -40,6 +40,10 @@ export const ForumComposerProvider = ({
           return;
         }
         const text = appendMention(form.values.text, username);
+        // Not awaited on purpose: this resolves with validation errors we don't act on,
+        // and the focus below is sequenced on the render rather than on that promise.
+        // Matches ElevationPrivilegeSync in ContentPostForm. (`no-void` rules out marking
+        // it with the void operator.)
         form.setFieldValue('text', text);
         // Opening the actions menu dismissed the keyboard and blurred the composer, so
         // without this the user is left looking at a mention they cannot type after.

--- a/src/Context/Providers/ForumComposerProvider.tsx
+++ b/src/Context/Providers/ForumComposerProvider.tsx
@@ -47,7 +47,9 @@ export const ForumComposerProvider = ({
         // caret is placed explicitly rather than wherever the field was last left.
         requestAnimationFrame(() => {
           inputRef.current?.focus();
-          inputRef.current?.setNativeProps({selection: {start: text.length, end: text.length}});
+          // setSelection rather than setNativeProps: this app runs the new architecture,
+          // where setNativeProps goes through legacy viewConfig attribute filtering.
+          inputRef.current?.setSelection(text.length, text.length);
         });
       },
     };

--- a/src/Context/Providers/ForumComposerProvider.tsx
+++ b/src/Context/Providers/ForumComposerProvider.tsx
@@ -1,0 +1,40 @@
+import {FormikProps} from 'formik';
+import React, {PropsWithChildren, useMemo} from 'react';
+
+import {ForumComposerContext, ForumComposerContextType} from '#src/Context/Contexts/ForumComposerContext';
+import {appendMention} from '#src/Libraries/StringUtils';
+import {PostContentData} from '#src/Structs/ControllerStructs';
+
+interface ForumComposerProviderProps {
+  /** Formik ref for the thread's ContentPostForm. */
+  formRef: React.RefObject<FormikProps<PostContentData> | null>;
+  /** False when the thread has no composer, which makes the context undefined. */
+  enabled: boolean;
+}
+
+/**
+ * Exposes the forum thread composer to the post list below it, so a post's actions menu
+ * can write into the composer without the screen having to drill a callback through the
+ * memoized list.
+ *
+ * Formik refreshes `innerRef` on every render, so `formRef.current.values` is the live
+ * composer content rather than a snapshot from when this provider mounted.
+ */
+export const ForumComposerProvider = ({formRef, enabled, children}: PropsWithChildren<ForumComposerProviderProps>) => {
+  const value = useMemo<ForumComposerContextType | undefined>(() => {
+    if (!enabled) {
+      return undefined;
+    }
+    return {
+      mentionUser: (username: string) => {
+        const form = formRef.current;
+        if (!form) {
+          return;
+        }
+        form.setFieldValue('text', appendMention(form.values.text, username));
+      },
+    };
+  }, [enabled, formRef]);
+
+  return <ForumComposerContext.Provider value={value}>{children}</ForumComposerContext.Provider>;
+};

--- a/src/Enums/Icons.ts
+++ b/src/Enums/Icons.ts
@@ -38,6 +38,7 @@ export enum AppIcons {
   report = 'alert-octagon',
   help = 'help-circle-outline',
   copy = 'content-copy',
+  reply = 'reply',
   // Users
   profile = 'account-details-outline',
   user = 'account',

--- a/src/Libraries/StringUtils.ts
+++ b/src/Libraries/StringUtils.ts
@@ -29,6 +29,12 @@ export const toSecureString = (originalText?: string): string => {
  * Matching is case-insensitive because Swiftarr matches mentions case-insensitively
  * (`ContentFilterable.filterForMention` uses `.caseInsensitive`).
  *
+ * Trailing punctuation is ignored, so `@user,` at the end of a clause still counts as a
+ * mention. Swiftarr's usernames are `[A-Za-z0-9]` with `-.+_` only ever appearing between
+ * alphanumerics, so anything non-alphanumeric at the end of a word cannot be part of the
+ * name. Leading characters are not stripped: Swiftarr's `(?<!\S)@` requires the `@` to
+ * follow whitespace or start the string, so `(@user` is not a mention to begin with.
+ *
  * @param text The text to search.
  * @param username The username to look for, without the leading `@`.
  * @returns True if the text already mentions that user.
@@ -38,7 +44,7 @@ export const isMentioned = (text: string, username: string): boolean => {
   return text
     .toLowerCase()
     .split(/\s+/)
-    .some(token => token === mention);
+    .some(token => token.replace(/[^a-z0-9]+$/, '') === mention);
 };
 
 /**

--- a/src/Libraries/StringUtils.ts
+++ b/src/Libraries/StringUtils.ts
@@ -24,6 +24,50 @@ export const toSecureString = (originalText?: string): string => {
 };
 
 /**
+ * Whether `username` is already @mentioned in `text` as a standalone word.
+ *
+ * Matching is case-insensitive because Swiftarr matches mentions case-insensitively
+ * (`ContentFilterable.filterForMention` uses `.caseInsensitive`).
+ *
+ * @param text The text to search.
+ * @param username The username to look for, without the leading `@`.
+ * @returns True if the text already mentions that user.
+ */
+export const isMentioned = (text: string, username: string): boolean => {
+  const mention = `@${username}`.toLowerCase();
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .some(token => token === mention);
+};
+
+/**
+ * Appends an @mention of `username` to composer text.
+ *
+ * Swiftarr only counts a mention when the `@` is preceded by whitespace or the start of
+ * the string (the `(?<!\S)@` in `ContentFilterable.getMentionsSet`), so this always
+ * inserts a separating space when the existing text does not end in whitespace.
+ *
+ * A user already mentioned in the text is not added again, so tapping Reply twice on the
+ * same author does not stack duplicates. Mentioning several different authors still works.
+ *
+ * @param text The current composer text.
+ * @param username The username to mention, without the leading `@`.
+ * @returns The text with the mention appended, followed by a trailing space to type after.
+ */
+export const appendMention = (text: string, username: string): string => {
+  if (isMentioned(text, username)) {
+    return text;
+  }
+  const mention = `@${username}`;
+  if (!text) {
+    return `${mention} `;
+  }
+  const separator = /\s$/.test(text) ? '' : ' ';
+  return `${text}${separator}${mention} `;
+};
+
+/**
  * Hide a tab/list badge when the count is 0. React Navigation treats a defined
  * `tabBarBadge` as visible, so a 0 would otherwise render as a badge.
  *

--- a/src/Screens/Forum/ForumThreadHelpScreen.tsx
+++ b/src/Screens/Forum/ForumThreadHelpScreen.tsx
@@ -30,6 +30,10 @@ export const ForumThreadHelpScreen = () => {
         </HelpChapterTitleView>
         <HelpChapterTitleView title={'Post Actions'}>
           <HelpTopicView>Long-press a post to access a menu of actions for that specific post.</HelpTopicView>
+          <HelpTopicView title={'Reply'} icon={AppIcons.reply}>
+            Adds an @mention of the post's author to the box at the bottom of the screen, so they are notified when you
+            post. Anything you have already typed is kept. Not shown on your own posts.
+          </HelpTopicView>
           <CopyButtonHelpTopicView />
           <ShareButtonHelpTopicView />
           <HelpTopicView title={'Edit'} icon={AppIcons.edit}>

--- a/src/Screens/Forum/Thread/ForumThreadScreenBase.tsx
+++ b/src/Screens/Forum/Thread/ForumThreadScreenBase.tsx
@@ -27,6 +27,7 @@ import {usePrivilege} from '#src/Context/Contexts/PrivilegeContext';
 import {useStyles} from '#src/Context/Contexts/StyleContext';
 import {useAppTheme} from '#src/Context/Contexts/ThemeContext';
 import {ElevationProvider} from '#src/Context/Providers/ElevationProvider';
+import {ForumComposerProvider} from '#src/Context/Providers/ForumComposerProvider';
 import {AppIcons} from '#src/Enums/Icons';
 import {PrivilegedUserAccounts} from '#src/Enums/UserAccessLevel';
 import {useForumCacheReducer} from '#src/Hooks/Forum/useForumCacheReducer';
@@ -295,44 +296,46 @@ const ForumThreadScreenBaseInner = ({
   });
 
   return (
-    <AppView>
-      <PostAsUserBanner />
-      <ListTitleView
-        title={forumData?.title ?? ''}
-        subtitle={pinnedPostsSubtitle}
-        icon={forumData?.isFavorite ? <AppIcon icon={AppIcons.favorite} small={true} /> : undefined}
-      />
-      {forumData?.isLocked && <ForumLockedView />}
-      <View style={commonStyles.flex}>
-        <ForumConversationListV2
-          postList={forumPosts}
-          handleLoadNext={handleLoadNext}
-          handleLoadPrevious={handleLoadPrevious}
-          refreshControl={<AppRefreshControl enabled={false} refreshing={refreshing} onRefresh={onRefresh} />}
-          forumData={forumData}
-          hasPreviousPage={hasPreviousPage}
-          getListHeader={getListHeader}
-          listRef={flatListRef}
-          hasNextPage={hasNextPage}
-          forumListData={forumListData}
-          initialScrollIndex={getInitialScrollIndex()}
-          onReadyToShow={onReadyToShow}
+    <ForumComposerProvider formRef={postFormRef} enabled={showForm}>
+      <AppView>
+        <PostAsUserBanner />
+        <ListTitleView
+          title={forumData?.title ?? ''}
+          subtitle={pinnedPostsSubtitle}
+          icon={forumData?.isFavorite ? <AppIcon icon={AppIcons.favorite} small={true} /> : undefined}
         />
-        {!readyToShow && (
-          <View style={overlayStyles.overlay}>
-            <ActivityIndicator size={'large'} />
-          </View>
+        {forumData?.isLocked && <ForumLockedView />}
+        <View style={commonStyles.flex}>
+          <ForumConversationListV2
+            postList={forumPosts}
+            handleLoadNext={handleLoadNext}
+            handleLoadPrevious={handleLoadPrevious}
+            refreshControl={<AppRefreshControl enabled={false} refreshing={refreshing} onRefresh={onRefresh} />}
+            forumData={forumData}
+            hasPreviousPage={hasPreviousPage}
+            getListHeader={getListHeader}
+            listRef={flatListRef}
+            hasNextPage={hasNextPage}
+            forumListData={forumListData}
+            initialScrollIndex={getInitialScrollIndex()}
+            onReadyToShow={onReadyToShow}
+          />
+          {!readyToShow && (
+            <View style={overlayStyles.overlay}>
+              <ActivityIndicator size={'large'} />
+            </View>
+          )}
+        </View>
+        {showForm && (
+          <ContentPostForm
+            onSubmit={onPostSubmit}
+            formRef={postFormRef}
+            enablePhotos={true}
+            maxLength={2000}
+            maxPhotos={maxForumPostImages}
+          />
         )}
-      </View>
-      {showForm && (
-        <ContentPostForm
-          onSubmit={onPostSubmit}
-          formRef={postFormRef}
-          enablePhotos={true}
-          maxLength={2000}
-          maxPhotos={maxForumPostImages}
-        />
-      )}
-    </AppView>
+      </AppView>
+    </ForumComposerProvider>
   );
 };

--- a/src/Screens/Forum/Thread/ForumThreadScreenBase.tsx
+++ b/src/Screens/Forum/Thread/ForumThreadScreenBase.tsx
@@ -2,7 +2,7 @@ import {InfiniteData, QueryObserverResult} from '@tanstack/react-query';
 import {FormikHelpers, FormikProps} from 'formik';
 import pluralize from 'pluralize';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, TextInput, View} from 'react-native';
 import {replaceTriggerValues} from 'react-native-controlled-mentions';
 import {ActivityIndicator} from 'react-native-paper';
 import {Item} from 'react-navigation-header-buttons';
@@ -92,6 +92,7 @@ const ForumThreadScreenBaseInner = ({
   const navigation = useCommonStack();
   const {asModerator, asTwitarrTeam, toggleModerator, toggleTwitarrTeam} = useElevation();
   const postFormRef = useRef<FormikProps<PostContentData>>(null);
+  const postInputRef = useRef<TextInput | null>(null);
   const postCreateMutation = useForumPostCreateMutation();
   const markReadMutation = useForumMarkReadMutation();
   const flatListRef = useRef<TConversationListV2Ref>(null);
@@ -296,7 +297,7 @@ const ForumThreadScreenBaseInner = ({
   });
 
   return (
-    <ForumComposerProvider formRef={postFormRef} enabled={showForm}>
+    <ForumComposerProvider formRef={postFormRef} inputRef={postInputRef} enabled={showForm}>
       <AppView>
         <PostAsUserBanner />
         <ListTitleView
@@ -330,6 +331,7 @@ const ForumThreadScreenBaseInner = ({
           <ContentPostForm
             onSubmit={onPostSubmit}
             formRef={postFormRef}
+            inputRef={postInputRef}
             enablePhotos={true}
             maxLength={2000}
             maxPhotos={maxForumPostImages}


### PR DESCRIPTION
Adds a Reply action to forum posts, which appends an `@mention` of the post's author to the thread composer.

Closes the client half of jocosocial/swiftarr#298.

## Motivation

From swiftarr#298:

> This may be a client-specific option, but have some button on a forum post to "reply" aka "automatically tag the author". Post authors don't know someone has directly "replied" to them unless mentioned.

No server change is needed for this. Swiftarr already scans post text for `@username` on every create and edit (`ContentFilterable.getMentionsSet`) and turns the diff into `forumMention` notifications (`ForumController.processForumMentions`). Prefilling the mention is enough for the author to be notified.

That's also the direction the project already settled on. swiftarr#62 proposed structural notification-on-reply and was closed in favour of mentions, on the grounds that reply notifications would "get out of hand and generate a storm of notifications" on popular posts, and that "@mentioning users will trigger a notification. That may be good enough." This change just makes the mention a one-tap action instead of something you type by hand.

## What's not here

The follow-up comment on #298 suggests also linking the replied-to post ID so clients can render a quote. That needs a server-side reply relation (`ForumPost` has no such column, and neither `PostData` nor `PostDetailData` has a reply field), so it's out of scope here. The two are additive rather than competing — this change stands on its own whether or not quoting is built later.

## Implementation

**`appendMention` / `isMentioned` (`src/Libraries/StringUtils.ts`)**

Builds the mention text the way swiftarr parses it:

- Always inserts a separating space when the composer text doesn't end in whitespace. Swiftarr's mention regex is `(?<!\S)@...`, so `hello@user` would not register as a mention.
- Matches case-insensitively, since swiftarr's `filterForMention` uses `.caseInsensitive`.
- Won't add a user who is already mentioned, so tapping Reply twice on the same author doesn't stack duplicates. Replying to several different authors still accumulates them.

**`ForumComposerContext` / `ForumComposerProvider`**

Exposes the thread composer to the post list below it, so the actions menu can write into it without drilling a callback through the memoized list.

Paper menu items remount inside `Portal.Host` and can't read context from the screen (the same constraint `docs/Navigation.md` describes for navigation hooks, and which the existing `// Apparently this doesn't get to be available in the sub items?` comment in `ForumPostActionsMenu` refers to). So the context is read in the menu, which is still in the screen tree, and the callback is passed down as a prop — matching how `navigation` is already handled for the other items.

Formik refreshes `innerRef` on every render, so `formRef.current.values` is the live composer content rather than a snapshot from when the provider mounted. Text the user has already typed is preserved.

Reply also refocuses the composer and puts the caret after the mention, so the common path — long-press, Reply, start typing — works without an extra tap. The `TextInput` is plumbed out of `MentionTextField` for that, and the caret is set with `TextInput.setSelection`, not `setNativeProps`, since this app runs the new architecture.

The platforms get stuck differently, which is why the call is `blur()` then `focus()` rather than just `focus()`. iOS fully blurs the composer when the menu opens. Android keeps focus and the caret but closes the soft keyboard, so `focus()` on an already-focused field does nothing there. Blurring first forces the keyboard back up on both.

**Where the action is hidden**

- **Post lists outside a thread** (mentions, alertwords, pinned, search) have no composer, so there's no provider and no Reply. They keep offering View In Thread, which is unchanged.
- **Locked threads** hide it for anyone who can't post, since the provider is disabled along with the composer.
- **Your own posts**, because swiftarr filters self-mentions (`userDidntMentionSelf`), so tagging yourself would notify nobody.

In a thread you get Reply; in a post list you get View In Thread. They don't both appear.

## Replying to an official moderator post notifies every moderator

Worth knowing before this ships. Reply inserts `@` + the post author's username, without inspecting who that author is. When a post was made with the post-as-moderator or post-as-TwitarrTeam toggle, the author is not the human — it's a shared account whose username is literally `moderator` or `TwitarrTeam`, both seeded in `AdminUsers.swift`. Swiftarr special-cases exactly those two names in `processForumMentions` and expands them to every account with that access level:

```swift
if adds.map({ $0.lowercased() }).contains("moderator") {
    let modMembers = req.userCache.allUsersWithAccessLevel(.moderator)
    ...addNotifications(users: modMembers..., type: .moderatorForumMention(postID), ...)
}
```

So tapping Reply on an official moderator post and posting notifies the whole mod team.

This is deliberate server behaviour, not something introduced here — the fan-out keys on the mention text, and typing `@moderator` by hand has always been the way to reach the team. Reaching whoever is on duty is arguably the right outcome for a reply to an official post, and a client can't notify the specific human anyway, since concealing that identity is the point of the pseudo-account.

What is new is that this PR turns it into a one-tap action where the user never types or reads the word "moderator". Flagging it rather than suppressing Reply on those posts, which would remove a reasonable action without making anything more correct. A line in the help topic would close the gap if reviewers want it.

Scope: those two strings are the only hardcoded username checks in mention handling anywhere in swiftarr, all four occurrences are in `processForumMentions`, and `NotificationType` has exactly two matching group cases. There is no twarrt or fez equivalent, so this is forum-posts-only. `admin`, `THO`, `prometheus` and `MicroKaraoke` get no special treatment.

## Testing

No CI covers tests yet (lint only), so everything below was run locally. `README.md` now documents how to reproduce it.

**Unit and static checks.** New tests for `appendMention` / `isMentioned` cover separator handling, case-insensitivity, the already-mentioned case, multiple distinct authors, trailing punctuation, and the punctuation swiftarr permits inside usernames. `npm run typecheck` and `npx eslint .` are clean. `npm test` passes apart from three date/time suites (`TestDateTime`, `TestNewDayMinuteCalculator`, `TestScheduleMarker`, 5 tests) which fail identically on a clean tree and are unrelated.

**End-to-end.** `__tests__/e2e/Forum/ForumPostReply.yaml` (Maestro) covers two scenarios: the common path — long-press a post, hit Reply, then type *without* tapping the composer first — and replying mid-sentence, where existing text must survive and the mention must land after it with a separating space. It is self-contained: it launches the app and navigates Forums → category → thread, with the category and thread as `env:` vars so it isn't welded to one fixture.

Running it needs a real stack — a local swiftarr, the app installed, Metro up, and a signed-in session:

```sh
# iOS
maestro test -e APP_ID=com.grantcohoe.tricordarr __tests__/e2e/Forum/ForumPostReply.yaml
# Android (different app ID; add --device when both are running)
maestro test -e APP_ID=com.tricordarr __tests__/e2e/Forum/ForumPostReply.yaml
```

**Results.** iOS 26.2 simulator: 19/19, twice. Android emulator (API 36): 19/19, twice, with the same flow file and no platform branches. Replying mid-sentence yields `hello @heidi ` — 13 chars, being text, separator, mention, trailing space — and posting it moved the recipient's `newForumMentionCount` from 2 to 3, so the mention is genuinely parsed by swiftarr and the notification fires.

**Mutation-tested, not just green.** Disabling the focus call makes the iOS run fail at scenario 1 (12 completed, 1 failed) and pass again once restored. That check is the reason the Android defect was caught at all: Android passed 19/19 *with the fix disabled*, which is what exposed that `focus()` was a no-op there. An earlier version of these assertions also passed for the wrong reason — unscoped text matches were matching post content rather than the composer — so they are now scoped with `id` + `text`.

**Known limits.** Maestro's `inputText` on Android injects into the focused view without needing the on-screen keyboard, so the Android run verifies text insertion but cannot assert keyboard state; that was checked by screenshot. Android also needs a non-Play AVD image, since Play images gate adb behind an "Allow USB debugging" dialog that no automated tool can dismiss. Both are written up in `README.md`.
