### PR TITLE
Combine post text with link when sharing forum posts

### DIFF
--- a/__tests__/unit/TestShareContentType.ts
+++ b/__tests__/unit/TestShareContentType.ts
@@ -10,7 +10,13 @@ jest.mock('@react-navigation/stack', () => ({
 import {FezType} from '#src/Enums/FezType';
 import {AppIcons} from '#src/Enums/Icons';
 import {getFezPublicShare} from '#src/Libraries/Moderation/Share';
-import {getShareLink, getShareSheetTitle, ShareContentType, ShareLinkMode} from '#src/Libraries/Sharing';
+import {
+  buildShareMessage,
+  getShareLink,
+  getShareSheetTitle,
+  ShareContentType,
+  ShareLinkMode,
+} from '#src/Libraries/Sharing';
 import {appLinkPrefix} from '#src/Libraries/UrlParser';
 
 describe('ShareContentType.performer', () => {
@@ -225,6 +231,19 @@ describe('getShareLink', () => {
         contentID: 'post-1',
       }),
     ).toBe(`${appLinkPrefix}moderate/forumpost/post-1`);
+  });
+});
+
+describe('buildShareMessage', () => {
+  const link = 'https://twitarr.com/forum/containingpost/post-1';
+
+  it('returns the bare link when there is no text', () => {
+    expect(buildShareMessage(undefined, link)).toBe(link);
+    expect(buildShareMessage('', link)).toBe(link);
+  });
+
+  it('combines text and link with a blank line', () => {
+    expect(buildShareMessage('Hello world', link)).toBe(`Hello world\n\n${link}`);
   });
 });
 

--- a/src/Components/Menus/Forum/ForumPostActionsMenu.tsx
+++ b/src/Components/Menus/Forum/ForumPostActionsMenu.tsx
@@ -62,7 +62,12 @@ export const ForumPostActionsMenu = ({
           closeMenu();
         }}
       />
-      <ShareMenuItem contentType={ShareContentType.forumPost} contentID={forumPost.postID} closeMenu={closeMenu} />
+      <ShareMenuItem
+        contentType={ShareContentType.forumPost}
+        contentID={forumPost.postID}
+        contentText={forumPost.text}
+        closeMenu={closeMenu}
+      />
       <Divider bold={true} />
       {bySelf && (
         <>

--- a/src/Components/Menus/Items/ShareMenuItem.tsx
+++ b/src/Components/Menus/Items/ShareMenuItem.tsx
@@ -10,6 +10,7 @@ import {ShareContentType} from '#src/Libraries/Sharing';
 interface ShareMenuItemProps {
   contentType: ShareContentType;
   contentID: string | number;
+  contentText?: string;
   closeMenu?: () => void;
   title?: string;
   leadingIcon?: string;
@@ -17,10 +18,12 @@ interface ShareMenuItemProps {
 
 /**
  * Actions-menu item that presents the share bottom sheet for this content.
+ * contentText, when provided, is combined with the share link when sharing to other apps.
  */
 export const ShareMenuItem = ({
   contentType,
   contentID,
+  contentText,
   closeMenu,
   title = 'Share',
   leadingIcon = AppIcons.share,
@@ -34,8 +37,8 @@ export const ShareMenuItem = ({
    */
   const handlePress = React.useCallback(() => {
     closeMenu?.();
-    openShareSheet(contentType, contentID);
-  }, [closeMenu, contentID, contentType, openShareSheet]);
+    openShareSheet(contentType, contentID, contentText);
+  }, [closeMenu, contentID, contentText, contentType, openShareSheet]);
 
   /**
    * If the user hasn't finished setup don't let them share content.

--- a/src/Components/Sheets/ShareBottomSheet.tsx
+++ b/src/Components/Sheets/ShareBottomSheet.tsx
@@ -21,7 +21,13 @@ import {styleDefaults} from '#src/Context/Providers/StyleProvider';
 import {AppIcons} from '#src/Enums/Icons';
 import {useClipboard} from '#src/Hooks/useClipboard';
 import {isAndroid} from '#src/Libraries/Platform/Detection';
-import {getShareLink, getShareSheetTitle, ShareContentType, ShareLinkMode} from '#src/Libraries/Sharing';
+import {
+  buildShareMessage,
+  getShareLink,
+  getShareSheetTitle,
+  ShareContentType,
+  ShareLinkMode,
+} from '#src/Libraries/Sharing';
 
 const handleHeight = 24;
 const titleHeight = 24;
@@ -34,6 +40,7 @@ const switchRowHeight = 32;
 interface ShareBottomSheetProps {
   contentType?: ShareContentType;
   contentID?: string | number;
+  contentText?: string;
   isPresented: boolean;
   onDismiss: () => void;
 }
@@ -43,7 +50,13 @@ interface ShareBottomSheetProps {
  * Copy, Share to Apps, and the QR use app deep links unless Share Web URLs is on.
  * Open in Browser always uses the web URL.
  */
-export const ShareBottomSheet = ({contentType, contentID, isPresented, onDismiss}: ShareBottomSheetProps) => {
+export const ShareBottomSheet = ({
+  contentType,
+  contentID,
+  contentText,
+  isPresented,
+  onDismiss,
+}: ShareBottomSheetProps) => {
   const sheetRef = useRef<BottomSheetModal>(null);
   const isSheetOpenRef = useRef(false);
   const [showQr, setShowQr] = useState(false);
@@ -182,10 +195,16 @@ export const ShareBottomSheet = ({contentType, contentID, isPresented, onDismiss
   /**
    * Opens the system share sheet for the content URL or app URI.
    * Android puts the link in message so it is sent as text; iOS uses url so the sheet can preview it.
+   * When contentText is present (e.g. a post body), both platforms share it combined with the
+   * link as one plaintext message instead, since there's no separate preview to preserve.
    */
   const handleShare = snackbarTry(async () => {
     await Share.open({
-      ...(isAndroid ? {message: shareTarget} : {url: shareTarget}),
+      ...(contentText
+        ? {message: buildShareMessage(contentText, shareTarget)}
+        : isAndroid
+          ? {message: shareTarget}
+          : {url: shareTarget}),
       failOnCancel: false,
     });
   });

--- a/src/Context/Contexts/ShareSheetContext.ts
+++ b/src/Context/Contexts/ShareSheetContext.ts
@@ -5,8 +5,9 @@ import {ShareContentType} from '#src/Libraries/Sharing';
 export interface ShareSheetContextType {
   /**
    * Present the share bottom sheet for the given content type and ID.
+   * contentText, when provided, is combined with the share link when sharing to other apps.
    */
-  openShareSheet: (contentType: ShareContentType, contentID: string | number) => void;
+  openShareSheet: (contentType: ShareContentType, contentID: string | number, contentText?: string) => void;
   /**
    * Dismiss the share bottom sheet.
    */

--- a/src/Context/Providers/ShareSheetProvider.tsx
+++ b/src/Context/Providers/ShareSheetProvider.tsx
@@ -11,11 +11,13 @@ import {ShareContentType} from '#src/Libraries/Sharing';
 export const ShareSheetProvider = ({children}: PropsWithChildren) => {
   const [contentType, setContentType] = useState<ShareContentType | undefined>();
   const [contentID, setContentID] = useState<string | number | undefined>();
+  const [contentText, setContentText] = useState<string | undefined>();
   const [isPresented, setIsPresented] = useState(false);
 
-  const openShareSheet = useCallback((type: ShareContentType, id: string | number) => {
+  const openShareSheet = useCallback((type: ShareContentType, id: string | number, text?: string) => {
     setContentType(type);
     setContentID(id);
+    setContentText(text);
     setIsPresented(true);
   }, []);
 
@@ -37,6 +39,7 @@ export const ShareSheetProvider = ({children}: PropsWithChildren) => {
       <ShareBottomSheet
         contentType={contentType}
         contentID={contentID}
+        contentText={contentText}
         isPresented={isPresented && contentType !== undefined && String(contentID ?? '').length > 0}
         onDismiss={closeShareSheet}
       />

--- a/src/Libraries/AppConfig.ts
+++ b/src/Libraries/AppConfig.ts
@@ -175,7 +175,7 @@ export const defaultAppConfig: AppConfig = {
     highlightForumAlertWords: true,
     autosavePhotos: true,
     autoCompressOversizedImages: true,
-    shareAppURI: true,
+    shareAppURI: false,
     seamailIncludeLfgs: true,
     seamailIncludePrivateEvents: true,
   },
@@ -249,7 +249,7 @@ export const getAppConfig = async () => {
     appConfig.userPreferences.autoCompressOversizedImages = true;
   }
   if (appConfig.userPreferences.shareAppURI === undefined) {
-    appConfig.userPreferences.shareAppURI = true;
+    appConfig.userPreferences.shareAppURI = false;
   }
   if (appConfig.userPreferences.seamailIncludeLfgs === undefined) {
     appConfig.userPreferences.seamailIncludeLfgs = true;

--- a/src/Libraries/Sharing.ts
+++ b/src/Libraries/Sharing.ts
@@ -99,3 +99,14 @@ export const getShareLink = ({mode, serverUrl, contentType, contentID}: GetShare
   }
   return joinUrl(serverUrl, relativePath);
 };
+
+/**
+ * Combines a post's text with its share link into one plaintext message.
+ * Falls back to the bare link when there is no text to share.
+ */
+export const buildShareMessage = (text: string | undefined, link: string): string => {
+  if (!text) {
+    return link;
+  }
+  return `${text}\n\n${link}`;
+};


### PR DESCRIPTION
## Problem
When sharing a forum post to another app (like iOS Notes or Messages), only a bare link was sent — the recipient had to open the link to see what was being shared.

## Solution
Forum post shares now bundle the post's text together with the share link into one plaintext message, so the shared content is readable without opening the app. A new `buildShareMessage` helper combines text and link (falling back to just the link when there's no text), and `ShareMenuItem`/`ShareSheetContext`/`ShareSheetProvider`/`ShareBottomSheet` were updated to thread an optional `contentText` through to it. Also changed the `shareAppURI` default to `false` so shared links point to the web URL by default rather than the app URI.

Refs #537 — this specifically covers sharing forum posts; broader iOS Send To support for other content types is not yet addressed.

### Testing
- Added unit tests for `buildShareMessage` covering bare-link and text+link cases.