### PR TITLE
Add post-as-privileged-user support to Announcements and unify forum/seamail post-as pickers

### DIFF
--- a/src/Components/Buttons/SegmentedButtons/AnnouncementPostAsButtons.tsx
+++ b/src/Components/Buttons/SegmentedButtons/AnnouncementPostAsButtons.tsx
@@ -1,0 +1,86 @@
+import {useField} from 'formik';
+import React, {useMemo} from 'react';
+import {SegmentedButtons, Text} from 'react-native-paper';
+
+import {useSession} from '#src/Context/Contexts/SessionContext';
+import {useStyles} from '#src/Context/Contexts/StyleContext';
+import {AppIcons} from '#src/Enums/Icons';
+import {PrivilegedUserAccounts, UserAccessLevel} from '#src/Enums/UserAccessLevel';
+import {useUserProfileQuery} from '#src/Queries/User/UserQueries';
+import {SegmentedButtonType} from '#src/Types';
+
+interface AnnouncementPostAsButtonsProps {
+  name: string;
+  testIDPrefix?: string;
+  label?: string;
+}
+
+/**
+ * Self / TwitarrTeam / THO / admin picker for authoring an Announcement. Unlike the
+ * Moderator/TwitarrTeam elevation used elsewhere, Announcements use an exact-accessLevel
+ * matrix (a THO caller may not post as TwitarrTeam, and vice versa) rather than the
+ * hierarchical `usePrivilege()` checks, and moderator is never a valid announcement author.
+ * "admin" is omitted when the caller already is admin, since it would be redundant with self.
+ */
+export const AnnouncementPostAsButtons = ({
+  name,
+  testIDPrefix = 'announcementPostAs',
+  label,
+}: AnnouncementPostAsButtonsProps) => {
+  const [field, , helpers] = useField<string>(name);
+  const {currentSession} = useSession();
+  const {data: profilePublicData} = useUserProfileQuery();
+  const {commonStyles} = useStyles();
+  const accessLevel = currentSession?.tokenData?.accessLevel;
+
+  const buttons = useMemo(() => {
+    const privileged: SegmentedButtonType[] = [];
+    if (accessLevel === UserAccessLevel.twitarrteam || accessLevel === UserAccessLevel.admin) {
+      privileged.push({
+        value: PrivilegedUserAccounts.TwitarrTeam,
+        label: 'TwitarrTeam',
+        icon: AppIcons.twitarrteam,
+        testID: `${testIDPrefix}TwitarrTeam-button`,
+      });
+    }
+    if (accessLevel === UserAccessLevel.tho || accessLevel === UserAccessLevel.admin) {
+      privileged.push({
+        value: PrivilegedUserAccounts.THO,
+        label: 'THO',
+        icon: AppIcons.tho,
+        testID: `${testIDPrefix}THO-button`,
+      });
+    }
+    if (accessLevel === UserAccessLevel.twitarrteam || accessLevel === UserAccessLevel.tho) {
+      privileged.push({
+        value: PrivilegedUserAccounts.admin,
+        label: 'Admin',
+        icon: AppIcons.admin,
+        testID: `${testIDPrefix}Admin-button`,
+      });
+    }
+    if (privileged.length === 0 || !profilePublicData) {
+      return [];
+    }
+    return [
+      {
+        value: 'self',
+        label: profilePublicData.header.username,
+        icon: AppIcons.user,
+        testID: `${testIDPrefix}Self-button`,
+      },
+      ...privileged,
+    ];
+  }, [accessLevel, profilePublicData, testIDPrefix]);
+
+  if (buttons.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {label && <Text style={commonStyles.marginBottomSmall}>{label}</Text>}
+      <SegmentedButtons value={field.value} onValueChange={helpers.setValue} buttons={buttons} />
+    </>
+  );
+};

--- a/src/Components/Buttons/SegmentedButtons/PrivilegedAccountButtons.tsx
+++ b/src/Components/Buttons/SegmentedButtons/PrivilegedAccountButtons.tsx
@@ -1,9 +1,10 @@
 import React, {useEffect, useState} from 'react';
-import {SegmentedButtons} from 'react-native-paper';
+import {SegmentedButtons, Text} from 'react-native-paper';
 
 import {AppIcon} from '#src/Components/Icons/AppIcon';
 import {useElevation} from '#src/Context/Contexts/ElevationContext';
 import {usePrivilege} from '#src/Context/Contexts/PrivilegeContext';
+import {useStyles} from '#src/Context/Contexts/StyleContext';
 import {useAppTheme} from '#src/Context/Contexts/ThemeContext';
 import {AppIcons} from '#src/Enums/Icons';
 import {PrivilegedUserAccounts} from '#src/Enums/UserAccessLevel';
@@ -15,6 +16,7 @@ interface PrivilegedAccountButtonsProps {
   moderatorNotificationCount?: number;
   twitarrTeamNotificationCount?: number;
   testIDPrefix?: string;
+  label?: string;
 }
 
 /**
@@ -26,12 +28,14 @@ export const PrivilegedAccountButtons = ({
   moderatorNotificationCount,
   twitarrTeamNotificationCount,
   testIDPrefix = 'privilegedAccount',
+  label,
 }: PrivilegedAccountButtonsProps) => {
   const {data: profilePublicData} = useUserProfileQuery();
   const {hasModerator, hasTwitarrTeam} = usePrivilege();
   const {asPrivilegedUser, becomeUser, clearElevation} = useElevation();
   const [forUser, setForUser] = useState(asPrivilegedUser || profilePublicData?.header.username);
   const {theme} = useAppTheme();
+  const {commonStyles} = useStyles();
   const [buttons, setButtons] = useState<SegmentedButtonType[]>([]);
 
   useEffect(() => {
@@ -91,7 +95,12 @@ export const PrivilegedAccountButtons = ({
   ]);
 
   if (buttons.length > 0 && forUser) {
-    return <SegmentedButtons value={forUser} onValueChange={setForUser} buttons={buttons} />;
+    return (
+      <>
+        {label && <Text style={commonStyles.marginBottomSmall}>{label}</Text>}
+        <SegmentedButtons value={forUser} onValueChange={setForUser} buttons={buttons} />
+      </>
+    );
   }
 
   return <></>;

--- a/src/Components/Forms/Admin/AdminAnnouncementForm.tsx
+++ b/src/Components/Forms/Admin/AdminAnnouncementForm.tsx
@@ -4,6 +4,7 @@ import {StyleSheet, View} from 'react-native';
 import * as Yup from 'yup';
 
 import {PrimaryActionButton} from '#src/Components/Buttons/PrimaryActionButton';
+import {AnnouncementPostAsButtons} from '#src/Components/Buttons/SegmentedButtons/AnnouncementPostAsButtons';
 import {DatePickerField} from '#src/Components/Forms/Fields/DatePickerField';
 import {DirtyDetectionField} from '#src/Components/Forms/Fields/DirtyDetectionField';
 import {TextField} from '#src/Components/Forms/Fields/TextField';
@@ -17,6 +18,7 @@ interface AdminAnnouncementFormProps {
   initialValues: AdminAnnouncementFormValues;
   onSubmit: (values: AdminAnnouncementFormValues, helpers: FormikHelpers<AdminAnnouncementFormValues>) => void;
   buttonText: string;
+  showPostAsOptions?: boolean;
 }
 
 /**
@@ -42,7 +44,12 @@ const validationSchema = Yup.object().shape({
   }),
 });
 
-export const AdminAnnouncementForm = ({initialValues, onSubmit, buttonText}: AdminAnnouncementFormProps) => {
+export const AdminAnnouncementForm = ({
+  initialValues,
+  onSubmit,
+  buttonText,
+  showPostAsOptions,
+}: AdminAnnouncementFormProps) => {
   const {commonStyles} = useStyles();
   const styles = StyleSheet.create({
     field: {
@@ -56,7 +63,7 @@ export const AdminAnnouncementForm = ({initialValues, onSubmit, buttonText}: Adm
       onSubmit={onSubmit}
       validationSchema={validationSchema}
       enableReinitialize={true}>
-      {({handleSubmit, isSubmitting, isValid}) => (
+      {({handleSubmit, isSubmitting, isValid, dirty}) => (
         <View>
           <DirtyDetectionField />
           <TextField
@@ -72,11 +79,16 @@ export const AdminAnnouncementForm = ({initialValues, onSubmit, buttonText}: Adm
           <View style={styles.field}>
             <TimePickerField name={'displayUntilTime'} testID={'announcementTime-button'} />
           </View>
+          {showPostAsOptions && (
+            <View style={styles.field}>
+              <AnnouncementPostAsButtons name={'postAsUser'} label={'Post as User'} />
+            </View>
+          )}
           <PrimaryActionButton
             testID={'announcementSave-button'}
             buttonText={buttonText}
             onPress={handleSubmit}
-            disabled={!isValid || isSubmitting}
+            disabled={!isValid || isSubmitting || !dirty}
             isLoading={isSubmitting}
           />
         </View>

--- a/src/Components/Forms/Forum/ForumCreateForm.tsx
+++ b/src/Components/Forms/Forum/ForumCreateForm.tsx
@@ -2,14 +2,11 @@ import {Formik, FormikHelpers, FormikProps, useFormikContext} from 'formik';
 import React, {useEffect} from 'react';
 import * as Yup from 'yup';
 
-import {BooleanField} from '#src/Components/Forms/Fields/BooleanField';
+import {PrivilegedAccountButtons} from '#src/Components/Buttons/SegmentedButtons/PrivilegedAccountButtons';
 import {DirtyDetectionField} from '#src/Components/Forms/Fields/DirtyDetectionField';
 import {TextField} from '#src/Components/Forms/Fields/TextField';
 import {PaddedContentView} from '#src/Components/Views/Content/PaddedContentView';
-import {useElevation} from '#src/Context/Contexts/ElevationContext';
-import {usePrivilege} from '#src/Context/Contexts/PrivilegeContext';
-import {AppIcons} from '#src/Enums/Icons';
-import {PrivilegedUserAccounts} from '#src/Enums/UserAccessLevel';
+import {useElevationFieldSync} from '#src/Hooks/Elevation/useElevationFieldSync';
 import {InfoStringValidation} from '#src/Libraries/ValidationSchema';
 import {ForumThreadValues} from '#src/Types/FormValues';
 
@@ -28,19 +25,9 @@ interface InnerFormProps {
 }
 
 const InnerForm = ({onValidationChange}: InnerFormProps) => {
-  const {values, isValid, dirty} = useFormikContext<ForumThreadValues>();
-  const {hasModerator, hasTwitarrTeam} = usePrivilege();
-  const {becomeUser, clearElevation} = useElevation();
+  const {isValid, dirty} = useFormikContext<ForumThreadValues>();
 
-  useEffect(() => {
-    if (values.postAsModerator) {
-      becomeUser(PrivilegedUserAccounts.moderator);
-    } else if (values.postAsTwitarrTeam) {
-      becomeUser(PrivilegedUserAccounts.TwitarrTeam);
-    } else {
-      clearElevation();
-    }
-  }, [values.postAsModerator, values.postAsTwitarrTeam, becomeUser, clearElevation]);
+  useElevationFieldSync('postAsModerator', 'postAsTwitarrTeam');
 
   useEffect(() => {
     // Only consider the form valid if it's both valid AND has been touched
@@ -51,24 +38,7 @@ const InnerForm = ({onValidationChange}: InnerFormProps) => {
     <PaddedContentView>
       <DirtyDetectionField />
       <TextField name={'title'} testID={'forumCreateTitle-input'} label={'Title'} />
-      {hasModerator && (
-        <BooleanField
-          name={'postAsModerator'}
-          testID={'forumCreateAsModerator-switch'}
-          label={'Post as Moderator'}
-          icon={AppIcons.moderator}
-          helperText={'This will also create the forum as the Moderator user.'}
-        />
-      )}
-      {hasTwitarrTeam && (
-        <BooleanField
-          name={'postAsTwitarrTeam'}
-          testID={'forumCreateAsTwitarrTeam-switch'}
-          label={'Post as TwitarrTeam'}
-          icon={AppIcons.twitarrteam}
-          helperText={'This will also create the forum as the TwitarrTeam user.'}
-        />
-      )}
+      <PrivilegedAccountButtons testIDPrefix={'forumCreatePostAs'} label={'Post as User'} />
     </PaddedContentView>
   );
 };

--- a/src/Components/Forms/SeamailCreateForm.tsx
+++ b/src/Components/Forms/SeamailCreateForm.tsx
@@ -17,6 +17,7 @@ interface SeamailCreateFormProps {
   formRef: React.RefObject<FormikProps<SeamailFormValues> | null>;
   initialValues: SeamailFormValues;
   onValidationChange?: (isValid: boolean) => void;
+  showPostAsOptions?: boolean;
 }
 
 const validationSchema = Yup.object().shape({
@@ -26,9 +27,10 @@ const validationSchema = Yup.object().shape({
 
 interface InnerSeamailCreateFormProps {
   onValidationChange?: (isValid: boolean) => void;
+  showPostAsOptions?: boolean;
 }
 
-const InnerSeamailCreateForm = ({onValidationChange}: InnerSeamailCreateFormProps) => {
+const InnerSeamailCreateForm = ({onValidationChange, showPostAsOptions = true}: InnerSeamailCreateFormProps) => {
   const {values, setFieldValue, isValid, dirty} = useFormikContext<SeamailFormValues>();
 
   useElevationFieldSync('createdByModerator', 'createdByTwitarrTeam');
@@ -56,12 +58,18 @@ const InnerSeamailCreateForm = ({onValidationChange}: InnerSeamailCreateFormProp
         onPress={() => setFieldValue('fezType', values.fezType === FezType.open ? FezType.closed : FezType.open)}
         value={values.fezType === FezType.open}
       />
-      <PrivilegedAccountButtons testIDPrefix={'seamailCreatePostAs'} label={'Post as User'} />
+      {showPostAsOptions && <PrivilegedAccountButtons testIDPrefix={'seamailCreatePostAs'} label={'Post as User'} />}
     </PaddedContentView>
   );
 };
 
-export const SeamailCreateForm = ({onSubmit, formRef, initialValues, onValidationChange}: SeamailCreateFormProps) => {
+export const SeamailCreateForm = ({
+  onSubmit,
+  formRef,
+  initialValues,
+  onValidationChange,
+  showPostAsOptions,
+}: SeamailCreateFormProps) => {
   return (
     <Formik
       innerRef={formRef}
@@ -69,7 +77,7 @@ export const SeamailCreateForm = ({onSubmit, formRef, initialValues, onValidatio
       initialValues={initialValues}
       onSubmit={onSubmit}
       validationSchema={validationSchema}>
-      <InnerSeamailCreateForm onValidationChange={onValidationChange} />
+      <InnerSeamailCreateForm onValidationChange={onValidationChange} showPostAsOptions={showPostAsOptions} />
     </Formik>
   );
 };

--- a/src/Components/Forms/SeamailCreateForm.tsx
+++ b/src/Components/Forms/SeamailCreateForm.tsx
@@ -2,16 +2,14 @@ import {Formik, FormikHelpers, FormikProps, useFormikContext} from 'formik';
 import React, {useEffect} from 'react';
 import * as Yup from 'yup';
 
+import {PrivilegedAccountButtons} from '#src/Components/Buttons/SegmentedButtons/PrivilegedAccountButtons';
 import {BooleanField} from '#src/Components/Forms/Fields/BooleanField';
 import {DirtyDetectionField} from '#src/Components/Forms/Fields/DirtyDetectionField';
 import {TextField} from '#src/Components/Forms/Fields/TextField';
 import {UserChipsField} from '#src/Components/Forms/Fields/UserChipsField';
 import {PaddedContentView} from '#src/Components/Views/Content/PaddedContentView';
-import {useElevation} from '#src/Context/Contexts/ElevationContext';
-import {usePrivilege} from '#src/Context/Contexts/PrivilegeContext';
 import {FezType} from '#src/Enums/FezType';
-import {AppIcons} from '#src/Enums/Icons';
-import {PrivilegedUserAccounts} from '#src/Enums/UserAccessLevel';
+import {useElevationFieldSync} from '#src/Hooks/Elevation/useElevationFieldSync';
 import {SeamailFormValues} from '#src/Types/FormValues';
 
 interface SeamailCreateFormProps {
@@ -32,18 +30,8 @@ interface InnerSeamailCreateFormProps {
 
 const InnerSeamailCreateForm = ({onValidationChange}: InnerSeamailCreateFormProps) => {
   const {values, setFieldValue, isValid, dirty} = useFormikContext<SeamailFormValues>();
-  const {hasTwitarrTeam, hasModerator} = usePrivilege();
-  const {becomeUser, clearElevation} = useElevation();
 
-  useEffect(() => {
-    if (values.createdByModerator) {
-      becomeUser(PrivilegedUserAccounts.moderator);
-    } else if (values.createdByTwitarrTeam) {
-      becomeUser(PrivilegedUserAccounts.TwitarrTeam);
-    } else {
-      clearElevation();
-    }
-  }, [values.createdByModerator, values.createdByTwitarrTeam, becomeUser, clearElevation]);
+  useElevationFieldSync('createdByModerator', 'createdByTwitarrTeam');
 
   useEffect(() => {
     // Only consider the form valid if it's both valid AND has been touched
@@ -68,24 +56,7 @@ const InnerSeamailCreateForm = ({onValidationChange}: InnerSeamailCreateFormProp
         onPress={() => setFieldValue('fezType', values.fezType === FezType.open ? FezType.closed : FezType.open)}
         value={values.fezType === FezType.open}
       />
-      {hasModerator && (
-        <BooleanField
-          name={'createdByModerator'}
-          testID={'seamailCreateAsModerator-switch'}
-          label={'Post as Moderator'}
-          icon={AppIcons.moderator}
-          helperText={'This will also create the seamail as the Moderator user.'}
-        />
-      )}
-      {hasTwitarrTeam && (
-        <BooleanField
-          name={'createdByTwitarrTeam'}
-          testID={'seamailCreateAsTwitarrTeam-switch'}
-          label={'Post as TwitarrTeam'}
-          icon={AppIcons.twitarrteam}
-          helperText={'This will also create the seamail as the TwitarrTeam user.'}
-        />
-      )}
+      <PrivilegedAccountButtons testIDPrefix={'seamailCreatePostAs'} label={'Post as User'} />
     </PaddedContentView>
   );
 };

--- a/src/Hooks/Elevation/useElevationFieldSync.ts
+++ b/src/Hooks/Elevation/useElevationFieldSync.ts
@@ -1,0 +1,20 @@
+import {useFormikContext} from 'formik';
+import {useEffect} from 'react';
+
+import {useElevation} from '#src/Context/Contexts/ElevationContext';
+import {PrivilegedUserAccounts} from '#src/Enums/UserAccessLevel';
+
+/**
+ * Keeps a form's postAs-moderator/postAs-TwitarrTeam boolean fields in sync with the
+ * screen's current elevation, so a `PrivilegedAccountButtons` picker (which drives
+ * elevation directly) can still feed forms/mutations that read these fields by name.
+ */
+export const useElevationFieldSync = (moderatorField: string, twitarrTeamField: string) => {
+  const {setFieldValue} = useFormikContext();
+  const {asPrivilegedUser} = useElevation();
+
+  useEffect(() => {
+    setFieldValue(moderatorField, asPrivilegedUser === PrivilegedUserAccounts.moderator);
+    setFieldValue(twitarrTeamField, asPrivilegedUser === PrivilegedUserAccounts.TwitarrTeam);
+  }, [asPrivilegedUser, moderatorField, twitarrTeamField, setFieldValue]);
+};

--- a/src/Screens/Admin/AdminAnnouncementEditScreen.tsx
+++ b/src/Screens/Admin/AdminAnnouncementEditScreen.tsx
@@ -51,12 +51,17 @@ const AdminAnnouncementEditScreenInner = ({route, navigation}: Props) => {
     text: announcement?.text ?? '',
     displayUntilDate: existing?.date ?? new Date(),
     displayUntilTime: existing?.time ?? {hours: 23, minutes: 59},
+    postAsUser: 'self',
   };
+  // Editing never applies postAsUser server-side (it only preserves the existing author),
+  // so the post-as picker only makes sense — and is only shown — when creating.
+  const showPostAsOptions = !announcement;
 
   const onSubmit = (values: AdminAnnouncementFormValues, helpers: FormikHelpers<AdminAnnouncementFormValues>) => {
     const data = {
       text: values.text,
       displayUntil: combineDateAndTime(values.displayUntilDate, values.displayUntilTime),
+      postAsUser: values.postAsUser !== 'self' ? values.postAsUser : undefined,
     };
     if (announcement) {
       editMutation.mutate(
@@ -88,6 +93,7 @@ const AdminAnnouncementEditScreenInner = ({route, navigation}: Props) => {
             initialValues={initialValues}
             onSubmit={onSubmit}
             buttonText={announcement ? 'Save' : 'Create'}
+            showPostAsOptions={showPostAsOptions}
           />
         </PaddedContentView>
         {announcement && (

--- a/src/Screens/Seamail/SeamailCreateScreen.tsx
+++ b/src/Screens/Seamail/SeamailCreateScreen.tsx
@@ -178,6 +178,7 @@ const SeamailCreateScreenInner = ({navigation, route}: Props) => {
           onSubmit={onFezSubmit}
           initialValues={initialFormValues}
           onValidationChange={setSeamailFormValid}
+          showPostAsOptions={false}
         />
       </ScrollingContentView>
       <ContentPostForm

--- a/src/Structs/AdminControllerStructs.tsx
+++ b/src/Structs/AdminControllerStructs.tsx
@@ -26,6 +26,10 @@ export interface AnnouncementCreateData {
   text: string;
   /// How long to display the announcement to users. ISO8601. Interpreted as floating time in the ship's Port timezone.
   displayUntil: string;
+  /// Author the announcement as this privileged account: "TwitarrTeam", "THO", or "admin".
+  /// Omitted, or the caller's own username, means the caller. Validated server-side against
+  /// the caller's access level. Edits validate this but never change the existing author.
+  postAsUser?: string;
 }
 
 /**

--- a/src/Types/FormValues.ts
+++ b/src/Types/FormValues.ts
@@ -143,6 +143,7 @@ export interface AdminAnnouncementFormValues {
   text: string;
   displayUntilDate: Date;
   displayUntilTime: StartTime;
+  postAsUser: string;
 }
 
 export interface AdminDailyThemeFormValues {


### PR DESCRIPTION
## Problem
Admins, TwitarrTeam, and THO users couldn't author an Announcement as a different privileged account (e.g. THO posting as TwitarrTeam), and the "post as Moderator/TwitarrTeam" controls in the Forum and Seamail creation forms used separate switches with duplicated elevation-syncing logic.

## Solution
In simple terms: added a new picker that lets privileged users choose who they're posting an Announcement as, and cleaned up the existing Forum/Seamail "post as" toggles so they share the same underlying logic instead of each reimplementing it.

Details:
- Added `AnnouncementPostAsButtons`, a segmented-button picker restricted to the exact-accessLevel matrix Announcements require (self / TwitarrTeam / THO / admin), since Announcements don't follow the hierarchical Moderator/TwitarrTeam privilege model used elsewhere.
- Wired the picker into `AdminAnnouncementForm` and `AdminAnnouncementEditScreen`, only showing it on create (edits preserve the existing author) and sending `postAsUser` to the API when it differs from `self`.
- Added `postAsUser` to `AnnouncementCreateData` and `AdminAnnouncementFormValues`.
- Replaced the separate "Post as Moderator"/"Post as TwitarrTeam" `BooleanField` switches in `ForumCreateForm` and `SeamailCreateForm` with the existing `PrivilegedAccountButtons` segmented picker, and extracted the shared elevation-sync effect into a new `useElevationFieldSync` hook to avoid duplicating that logic.
- `PrivilegedAccountButtons` gained an optional `label` prop; `SeamailCreateForm` gained a `showPostAsOptions` prop (used to hide the picker on the Seamail create screen).
- The Announcement save button is now also disabled when the form isn't dirty.

## Testing
TODO: manual verification in the app (create/edit an Announcement as different privileged accounts; verify Forum/Seamail post-as pickers still elevate correctly).